### PR TITLE
don't panic on imported type in `add_wasi_and_stubs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ fn add_wasi_and_stubs(
             WorldItem::Function(function) => {
                 functions.entry(None).or_default().push(&function.name);
             }
-            WorldItem::Type(_) => unreachable!(),
+            WorldItem::Type(_) => {}
         }
     }
 


### PR DESCRIPTION
Just skip over imported types rather than panicking.