### PR TITLE
handle when same componentize-py.toml appears twice in  PYTHON_PATH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -13,7 +13,7 @@ snapshot, which may differ from later revisions.
 ## Prerequisites
 
 * `Wasmtime` 16.0.0 (later versions may use a different, incompatible `wasi-cli` snapshot)
-* `componentize-py` 0.9.1
+* `componentize-py` 0.9.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -21,7 +21,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v16.0.0.
 
 ```
 cargo install --version 16.0.0 wasmtime-cli
-pip install componentize-py==0.9.1
+pip install componentize-py==0.9.2
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -14,7 +14,7 @@ which may differ from later revisions.
 ## Prerequisites
 
 * `Wasmtime` 16.0.0 (later versions may use a different, incompatible `wasi-http` snapshot)
-* `componentize-py` 0.9.1
+* `componentize-py` 0.9.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -22,7 +22,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v16.0.0.
 
 ```
 cargo install --version 16.0.0 wasmtime-cli
-pip install componentize-py==0.9.1
+pip install componentize-py==0.9.2
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 16.0.0 (later versions may use a different, incompatible `wasi-cli` snapshot)
-* `componentize-py` 0.9.1
+* `componentize-py` 0.9.2
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v16.0.0.
 
 ```
 cargo install --version 16.0.0 wasmtime-cli
-    pip install componentize-py==0.9.1
+    pip install componentize-py==0.9.2
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -14,7 +14,7 @@ snapshot, which may differ from later revisions.
 ## Prerequisites
 
 * `Wasmtime` 16.0.0 (later versions may use a different, incompatible `wasi-cli` snapshot)
-* `componentize-py` 0.9.1
+* `componentize-py` 0.9.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -22,7 +22,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v16.0.0.
 
 ```
 cargo install --version 16.0.0 wasmtime-cli
-pip install componentize-py==0.9.1
+pip install componentize-py==0.9.2
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.9.1"
+version = "0.9.2"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
In this case, we need to decide which directory "owns" the file, which affects how we derive package names relative to that directory.  For example, if both `foo` and `foo/.venv/lib/python3.12/site-packages` are in `PYTHON_PATH`, and we
find a componentize-py.toml file under the latter, then we'll also find it under the former.  In that case, we consider the latter to be the "owner" of the file.
