### PR TITLE
append `Raises` line to function docstrings as appropriate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
If the WIT representation of a function returns `result<A,B>`, then we generate a Python function that returns `A` and raises `Err(B)`.  Since there's currently no way of representing the `Err(B)` part in the function's signature, we do the next best thing: put it in the docstring.

Fixes #53