### PR TITLE
switch types generated for resources to be context managers

### DIFF
--- a/bundled/poll_loop.py
+++ b/bundled/poll_loop.py
@@ -63,7 +63,7 @@ class Stream:
             except Err as e:
                 if isinstance(e.value, StreamErrorClosed):
                     if self.stream is not None:
-                        self.stream.drop()
+                        self.stream.__exit__()
                         self.stream = None
                     if self.body is not None:
                         IncomingBody.finish(self.body)
@@ -102,7 +102,7 @@ class Sink:
     def close(self):
         """Close the stream, indicating no further data will be written."""
 
-        self.stream.drop()
+        self.stream.__exit__()
         self.stream = None
         OutgoingBody.finish(self.body, None)
         self.body = None
@@ -140,7 +140,7 @@ class PollLoop(asyncio.AbstractEventLoop):
                 
                 for (ready, pollable), waker in zip(zip(ready, pollables), wakers):
                     if ready:
-                        pollable.drop()
+                        pollable.__exit__()
                         waker.set_result(None)
                     else:
                         new_wakers.append((pollable, waker))

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1214,9 +1214,6 @@ class {camel}(Flag):
                                 }
                             })
                             .map(method)
-                            // TODO: make resource classes context managers per
-                            // https://docs.python.org/3/reference/datamodel.html#context-managers and call this
-                            // `__exit__`:
                             .chain(iter::once({
                                 let newline = '\n';
                                 let indent = "        ";

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1223,18 +1223,22 @@ class {camel}(Flag):
                                 let doc = "Release this resource.";
                                 let docs =
                                     format!(r#""""{newline}{indent}{doc}{newline}{indent}"""{newline}{indent}"#);
-
+                                let enter = r#"
+    def __enter__(self):
+        """Returns self"""
+        return self
+                                "#;
                                 if stub_runtime_calls {
                                     format!(
-                                        "
-    def drop(self):
+                                        "{enter}                                    
+    def __exit__(self, *args):
         {docs}raise NotImplementedError
 "
                                     )
                                 } else {
                                     format!(
-                                        "
-    def drop(self):
+                                        "{enter}
+    def __exit__(self, *args):
         {docs}(_, func, args, _) = self.finalizer.detach()
         self.handle = None
         func(args[0], args[1])

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -183,7 +183,9 @@ class Thing(resource_import_and_export.Thing):
 
     @staticmethod
     def baz(a: Self, b: Self) -> Self:
-        return Thing(HostThing.baz(a.value, b.value).foo() + 9)
+        with HostThing.baz(a.value, b.value) as bar:
+            value = bar.foo()
+        return Thing(value + 9)
 "#,
     ),
     (


### PR DESCRIPTION
fixes #54 

Types generated for representing resources now are context managers so that it is more idiomatic and users can avoid having to manually call `drop()`.