### PR TITLE
use fully-qualified names in doc references

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -71,6 +71,12 @@ pub struct Bindings {
     ///
     /// This will be created if it does not already exist.
     pub output_dir: PathBuf,
+
+    /// Optional name of top-level module to use for bindings.
+    ///
+    /// If this is not specified, the module name will be derived from the world name.
+    #[arg(long)]
+    pub world_module: Option<String>,
 }
 
 pub fn run<T: Into<OsString> + Clone, I: IntoIterator<Item = T>>(args: I) -> Result<()> {
@@ -87,6 +93,7 @@ fn generate_bindings(common: Common, bindings: Bindings) -> Result<()> {
             .wit_path
             .unwrap_or_else(|| Path::new("wit").to_owned()),
         common.world.as_deref(),
+        bindings.world_module.as_deref(),
         &bindings.output_dir,
     )
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -29,13 +29,14 @@ fn python_componentize(
 
 #[pyo3::pyfunction]
 #[pyo3(name = "generate_bindings")]
-#[pyo3(signature = (wit_path, world, output_dir))]
+#[pyo3(signature = (wit_path, world, world_module, output_dir))]
 fn python_generate_bindings(
     wit_path: PathBuf,
     world: Option<&str>,
+    world_module: Option<&str>,
     output_dir: PathBuf,
 ) -> PyResult<()> {
-    crate::generate_bindings(&wit_path, world, &output_dir)
+    crate::generate_bindings(&wit_path, world, world_module, &output_dir)
         .map_err(|e| PyAssertionError::new_err(format!("{e:?}")))
 }
 


### PR DESCRIPTION
This allows e.g. `pdoc3` to turn them into the appropriate hyperlinks.