### PR TITLE
remove caveats in example README.md files

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -3,16 +3,13 @@
 This is an example of how to use [componentize-py] and [Wasmtime] to build and
 run a Python-based component targetting the [wasi-cli] `command` world.
 
-Note that, as of this writing, `wasi-cli` has not yet stabilized.  Here we use a
-snapshot, which may differ from later revisions.
-
 [componentize-py]: https://github.com/bytecodealliance/componentize-py
 [Wasmtime]: https://github.com/bytecodealliance/wasmtime
 [wasi-cli]: https://github.com/WebAssembly/wasi-cli
 
 ## Prerequisites
 
-* `Wasmtime` 17.0.0 (later versions may use a different, incompatible `wasi-cli` snapshot)
+* `Wasmtime` 17.0.0 or later
 * `componentize-py` 0.11.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -3,17 +3,13 @@
 This is an example of how to use [componentize-py] and [Wasmtime] to build and
 run a Python-based component targetting the [wasi-http] `proxy` world.
 
-Note that, as of this writing, neither `wasi-http` nor the portions of
-`wasi-cli` on which it is based have stabilized.  Here we use a snapshot of both,
-which may differ from later revisions.
-
 [componentize-py]: https://github.com/bytecodealliance/componentize-py
 [Wasmtime]: https://github.com/bytecodealliance/wasmtime
 [wasi-http]: https://github.com/WebAssembly/wasi-http
 
 ## Prerequisites
 
-* `Wasmtime` 17.0.0 (later versions may use a different, incompatible `wasi-http` snapshot)
+* `Wasmtime` 17.0.0 or later
 * `componentize-py` 0.11.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -10,7 +10,7 @@ within a guest component.
 
 ## Prerequisites
 
-* `wasmtime` 17.0.0 (later versions may use a different, incompatible `wasi-cli` snapshot)
+* `wasmtime` 17.0.0 or later
 * `componentize-py` 0.11.0
 * `NumPy`, built for WASI
 

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -4,16 +4,13 @@ This is an example of how to use [componentize-py] and [Wasmtime] to build and
 run a Python-based component targetting the [wasi-cli] `command` world and
 making an outbound TCP request using `wasi-sockets`.
 
-Note that, as of this writing, `wasi-cli` has not yet stabilized.  Here we use a
-snapshot, which may differ from later revisions.
-
 [componentize-py]: https://github.com/bytecodealliance/componentize-py
 [Wasmtime]: https://github.com/bytecodealliance/wasmtime
 [wasi-cli]: https://github.com/WebAssembly/wasi-cli
 
 ## Prerequisites
 
-* `Wasmtime` 17.0.0 (later versions may use a different, incompatible `wasi-cli` snapshot)
+* `Wasmtime` 17.0.0 or later
 * `componentize-py` 0.11.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If


### PR DESCRIPTION
WASI 0.2.0 is stable now, so no need to warn about version instability.