### PR TITLE
rename "lift" and "lower" functions

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -185,13 +185,13 @@ pub fn make_bindings(resolve: &Resolve, world: WorldId, summary: &Summary) -> Re
                     .get_index_of(&(function.interface.as_ref().map(|i| i.name), function.name))
                     .unwrap()
                     .try_into()?,
-                // The next two `dispatch_index`es should be the lift and lower functions (see ordering in
+                // The next two `dispatch_index`es should be the from_canon and to_canon functions (see ordering in
                 // `Summary::visit_function`):
                 dispatch_index,
                 dispatch_index + 1,
             ),
-            FunctionKind::ExportLift => gen.compile_export_lift(),
-            FunctionKind::ExportLower => gen.compile_export_lower(),
+            FunctionKind::ExportFromCanon => gen.compile_export_from_canon(),
+            FunctionKind::ExportToCanon => gen.compile_export_to_canon(),
             FunctionKind::ExportPostReturn => gen.compile_export_post_return(),
             FunctionKind::ResourceNew => {
                 gen.compile_resource_new(import_index.try_into().unwrap());

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -54,8 +54,8 @@ pub enum FunctionKind {
     ResourceDropLocal,
     ResourceDropRemote,
     Export,
-    ExportLift,
-    ExportLower,
+    ExportFromCanon,
+    ExportToCanon,
     ExportPostReturn,
 }
 
@@ -102,8 +102,8 @@ impl<'a> MyFunction<'a> {
                     FunctionKind::ResourceDropLocal => "-resource-drop-local",
                     FunctionKind::ResourceDropRemote => "-resource-drop-remote",
                     FunctionKind::Export => "-export",
-                    FunctionKind::ExportLift => "-lift",
-                    FunctionKind::ExportLower => "-lower",
+                    FunctionKind::ExportFromCanon => "-from-canon",
+                    FunctionKind::ExportToCanon => "-to-canon",
                     FunctionKind::ExportPostReturn => "-post-return",
                 }
             )
@@ -137,8 +137,8 @@ impl<'a> MyFunction<'a> {
             | FunctionKind::ResourceRep
             | FunctionKind::ResourceDropLocal
             | FunctionKind::ResourceDropRemote
-            | FunctionKind::ExportLift
-            | FunctionKind::ExportLower => (
+            | FunctionKind::ExportFromCanon
+            | FunctionKind::ExportToCanon => (
                 vec![ValType::I32; DISPATCHABLE_CORE_PARAM_COUNT],
                 Vec::new(),
             ),
@@ -153,8 +153,8 @@ impl<'a> MyFunction<'a> {
             | FunctionKind::ResourceRep
             | FunctionKind::ResourceDropLocal
             | FunctionKind::ResourceDropRemote
-            | FunctionKind::ExportLift
-            | FunctionKind::ExportLower => true,
+            | FunctionKind::ExportFromCanon
+            | FunctionKind::ExportToCanon => true,
             FunctionKind::Export | FunctionKind::ExportPostReturn => false,
         }
     }
@@ -422,8 +422,8 @@ impl<'a> Summary<'a> {
                 // NB: We rely on this order when compiling, so please don't change it:
                 // todo: make this less fragile
                 self.push_function(make(FunctionKind::Export));
-                self.push_function(make(FunctionKind::ExportLift));
-                self.push_function(make(FunctionKind::ExportLower));
+                self.push_function(make(FunctionKind::ExportFromCanon));
+                self.push_function(make(FunctionKind::ExportToCanon));
                 if abi::record_abi(self.resolve, results.types())
                     .flattened
                     .len()


### PR DESCRIPTION
The "lift" and "lower" terminology was misleading and confusing for anyone familiar with their meanings in the Component Model ABI.  I was overloading them to mean "lift from the canonical ABI representation to Python" and "lower from Python to the canonical ABI representation", respectively, but that's easy to confuse with how the canonical ABI uses them to mean "lift a core function to a component function" and "lower a component function to a core function".

In order to avoid such confusion, I've renamed them to "from-canon" and "to-canon", respectively.