### PR TITLE
fix: Return future.result from run_until_complete

### DIFF
--- a/bundled/poll_loop.py
+++ b/bundled/poll_loop.py
@@ -150,7 +150,7 @@ class PollLoop(asyncio.AbstractEventLoop):
             if self.exception is not None:
                 raise self.exception
             
-        future.result()
+        return future.result()
 
     def is_running(self):
         return self.running


### PR DESCRIPTION
Python doesn't have implicit return values, so make sure to return the value of the future at the end of the function.