### PR TITLE
reset wasi-libc preopen table prior to pre-init snapshot

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  WASI_SDK_VERSION: 20.26g68203b20b82e
-  WASI_SDK_RELEASE: wasi-sockets-alpha-2
+  WASI_SDK_VERSION: 20.46gf3a1f8991535
+  WASI_SDK_RELEASE: wasi-sockets-alpha-5
 
 jobs:
   linux:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  WASI_SDK_VERSION: 20.26g68203b20b82e
-  WASI_SDK_RELEASE: wasi-sockets-alpha-2
+  WASI_SDK_VERSION: 20.46gf3a1f8991535
+  WASI_SDK_RELEASE: wasi-sockets-alpha-5
 
 jobs:
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ variable).  Replace `linux` with `macos` or `mingw` (Windows) below depending on
 your OS.
 
 ```shell
-curl -LO https://github.com/dicej/wasi-sdk/releases/download/wasi-sockets-alpha-2/wasi-sdk-20.26g68203b20b82e-linux.tar.gz
-tar xf wasi-sdk-20.26g68203b20b82e-linux.tar.gz
-sudo mv wasi-sdk-20.26g68203b20b82e /opt/wasi-sdk
+curl -LO https://github.com/dicej/wasi-sdk/releases/download/wasi-sockets-alpha-5/wasi-sdk-20.46gf3a1f8991535-linux.tar.gz
+tar xf wasi-sdk-20.46gf3a1f8991535-linux.tar.gz
+sudo mv wasi-sdk-20.46gf3a1f8991535 /opt/wasi-sdk
 export WASI_SDK_PATH=/opt/wasi-sdk
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.0
+* `componentize-py` 0.13.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.0
+pip install componentize-py==0.13.1
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.0
+* `componentize-py` 0.13.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.0
+pip install componentize-py==0.13.1
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.0
+* `componentize-py` 0.13.1
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.0
+pip install componentize-py==0.13.1
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -8,10 +8,10 @@ sandboxed Python code snippets from within a Python app.
 ## Prerequisites
 
 * `wasmtime-py` 18.0.0 or later
-* `componentize-py` 0.13.0
+* `componentize-py` 0.13.1
 
 ```
-pip install componentize-py==0.13.0 wasmtime==18.0.2
+pip install componentize-py==0.13.1 wasmtime==18.0.2
 ```
 
 ## Running the demo

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -11,7 +11,7 @@ making an outbound TCP request using `wasi-sockets`.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.0
+* `componentize-py` 0.13.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.0
+pip install componentize-py==0.13.1
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.13.0"
+version = "0.13.1"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -383,8 +383,16 @@ impl Guest for MyExports {
             fn reset_adapter_state();
         }
 
+        // This tells wasi-libc to reset its preopen state, forcing re-initialization at runtime.
+        #[link(wasm_import_module = "env")]
+        extern "C" {
+            #[cfg_attr(target_arch = "wasm32", link_name = "__wasilibc_reset_preopens")]
+            fn wasilibc_reset_preopens();
+        }
+
         unsafe {
             reset_adapter_state();
+            wasilibc_reset_preopens();
         }
 
         result

--- a/src/test/python_source/app.py
+++ b/src/test/python_source/app.py
@@ -1,3 +1,4 @@
+import traceback
 import tests
 import resource_borrow_export
 import resource_aggregates
@@ -7,7 +8,7 @@ from tests import exports, imports
 from tests.imports import resource_borrow_import
 from tests.imports import simple_import_and_export
 from tests.exports import resource_alias2
-from tests.types import Result, Ok
+from tests.types import Result, Ok, Err
 from typing import Tuple, List, Optional
 from foo_sdk.wit import exports as foo_exports
 from foo_sdk.wit.imports.foo_interface import test as foo_test
@@ -122,10 +123,17 @@ class Tests(tests.Tests):
         return resource_borrow_import.foo(resource_borrow_import.Thing(v + 1)) + 4
 
     def test_resource_alias(self, things: List[imports.resource_alias1.Thing]) -> List[imports.resource_alias1.Thing]:
-       return things
+        return things
 
     def add(self, a: imports.resource_floats.Float, b: imports.resource_floats.Float) -> imports.resource_floats.Float:
-       return imports.resource_floats.Float(a.get() + b.get() + 5)
+        return imports.resource_floats.Float(a.get() + b.get() + 5)
+
+    def read_file(self, path: str) -> bytes:
+        try:
+            with open(file=path, mode="rb") as f:
+                return f.read()
+        except:
+            raise Err(traceback.format_exc())
    
 class FooInterface(foo_exports.FooInterface):
     def test(self, s: str) -> str:

--- a/src/test/wit/tests.wit
+++ b/src/test/wit/tests.wit
@@ -177,4 +177,6 @@ world tests {
   export test-resource-alias: func(things: list<thing>) -> list<thing>;
 
   export add: func(a: borrow<float>, b: borrow<float>) -> own<float>;
+
+  export read-file: func(path: string) -> result<list<u8>, string>;
 }


### PR DESCRIPTION
This forces wasi-libc to re-initialize the preopen table when the snapshot is restored, making the runtime preopens available in place of the build-time preopens.