### PR TITLE
include user site-packages in default Python path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.1
+* `componentize-py` 0.13.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.1
+pip install componentize-py==0.13.2
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.1
+* `componentize-py` 0.13.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.1
+pip install componentize-py==0.13.2
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.1
+* `componentize-py` 0.13.2
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.1
+pip install componentize-py==0.13.2
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -8,10 +8,10 @@ sandboxed Python code snippets from within a Python app.
 ## Prerequisites
 
 * `wasmtime-py` 18.0.0 or later
-* `componentize-py` 0.13.1
+* `componentize-py` 0.13.2
 
 ```
-pip install componentize-py==0.13.1 wasmtime==18.0.2
+pip install componentize-py==0.13.2 wasmtime==18.0.2
 ```
 
 ## Running the demo

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -11,7 +11,7 @@ making an outbound TCP request using `wasi-sockets`.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.1
+* `componentize-py` 0.13.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.1
+pip install componentize-py==0.13.2
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.13.1"
+version = "0.13.2"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,12 @@ pub async fn componentize(
     isyswasfa: Option<&str>,
     stub_wasi: bool,
 ) -> Result<()> {
+    // Remove non-existent elements from `python_path` so we don't choke on them later:
+    let python_path = &python_path
+        .iter()
+        .filter_map(|&s| Path::new(s).exists().then_some(s))
+        .collect::<Vec<_>>();
+
     // Untar the embedded copy of the Python standard library into a temporary directory
     let stdlib = tempfile::tempdir()?;
 


### PR DESCRIPTION
In many (most?) Python installations, this is where e.g. `pip install`'d packages end up.