### PR TITLE
fix unresolved symbol issue when using latest Rust `nightly`

### DIFF
--- a/pyo3-config.txt
+++ b/pyo3-config.txt
@@ -1,8 +1,8 @@
 implementation=CPython
-version=3.11
+version=3.12
 shared=true
 abi3=false
-lib_name=python3.11
+lib_name=python3.12
 pointer_width=32
 build_flags=
 suppress_build_script_link_lines=false

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1256,3 +1256,13 @@ pub mod dl {
         LIBRARIES.0 = libraries;
     }
 }
+
+// As of this writing, recent Rust `nightly` builds include a version of the `libc` crate that expects `wasi-libc`
+// to define the following global variables, but `wasi-libc` defines them as preprocessor constants which aren't
+// visible at link time, so we need to define them somewhere.  Ideally, we should fix this upstream, but for now we
+// work around it:
+
+#[no_mangle]
+static _CLOCK_PROCESS_CPUTIME_ID: u8 = 2;
+#[no_mangle]
+static _CLOCK_THREAD_CPUTIME_ID: u8 = 3;

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -73,7 +73,6 @@ pub struct PackageName<'a> {
 #[derive(Clone)]
 pub struct MyInterface<'a> {
     pub id: InterfaceId,
-    pub package: Option<PackageName<'a>>,
     pub name: &'a str,
     pub docs: Option<&'a str>,
     pub resource_directions: im_rc::HashMap<TypeId, Direction>,
@@ -559,7 +558,6 @@ impl<'a> Summary<'a> {
                     self.resource_state = Some(ResourceState {
                         direction,
                         interface: Some(MyInterface {
-                            package,
                             name: item_name,
                             id: *id,
                             docs: interface.docs.contents.as_deref(),
@@ -578,7 +576,6 @@ impl<'a> Summary<'a> {
                     for (func_name, func) in &interface.functions {
                         self.visit_function(
                             Some(MyInterface {
-                                package,
                                 name: item_name,
                                 id: *id,
                                 docs: interface.docs.contents.as_deref(),


### PR DESCRIPTION
As of this writing, recent Rust `nightly` builds include a version of the `libc` crate that expects `wasi-libc` to define the following global variables, but `wasi-libc` defines them as preprocessor constants which aren't visible at link time, so we need to define them somewhere.  Ideally, we should fix this upstream, but for now we work around it.

This commit also addresses an unused field warning.

Fixes #86