### PR TITLE
ensure `dlopen` symbol table uses forward slashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.3
+* `componentize-py` 0.13.4
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.3
+pip install componentize-py==0.13.4
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.3
+* `componentize-py` 0.13.4
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.3
+pip install componentize-py==0.13.4
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.3
+* `componentize-py` 0.13.4
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.3
+pip install componentize-py==0.13.4
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -8,10 +8,10 @@ sandboxed Python code snippets from within a Python app.
 ## Prerequisites
 
 * `wasmtime-py` 18.0.0 or later
-* `componentize-py` 0.13.3
+* `componentize-py` 0.13.4
 
 ```
-pip install componentize-py==0.13.3 wasmtime==18.0.2
+pip install componentize-py==0.13.4 wasmtime==18.0.2
 ```
 
 ## Running the demo

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -11,7 +11,7 @@ making an outbound TCP request using `wasi-sockets`.
 ## Prerequisites
 
 * `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.13.3
+* `componentize-py` 0.13.4
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
 
 ```
 cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.13.3
+pip install componentize-py==0.13.4
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.13.3"
+version = "0.13.4"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,8 @@ pub async fn componentize(
                 .strip_prefix(path)
                 .unwrap()
                 .to_str()
-                .context("non-UTF-8 path")?;
+                .context("non-UTF-8 path")?
+		.replace('\\', "/");
 
             libraries.push(Library {
                 name: format!("/{index}/{path}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,7 +462,7 @@ pub async fn componentize(
                 .unwrap()
                 .to_str()
                 .context("non-UTF-8 path")?
-		.replace('\\', "/");
+                .replace('\\', "/");
 
             libraries.push(Library {
                 name: format!("/{index}/{path}"),
@@ -916,9 +916,9 @@ fn search_directory(
                     // subdirectory to be the true owner of the file.  This is important later, when we derive a
                     // package name by stripping the root directory from the file path.
                     if root > existing.root {
-                        existing.module = module.clone();
-                        existing.root = root.to_owned();
-                        existing.path = path.parent().unwrap().to_owned();
+                        module.clone_into(&mut existing.module);
+                        root.clone_into(&mut existing.root);
+                        path.parent().unwrap().clone_into(&mut existing.path);
                     }
                     push = false;
                     break;

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1398,7 +1398,7 @@ impl<'a> Summary<'a> {
                     .join("\n    ");
 
                 if fields.is_empty() {
-                    fields = "pass".to_owned()
+                    "pass".to_owned().clone_into(&mut fields)
                 }
 
                 let docs = docstring(world_module, docs, 1, None);


### PR DESCRIPTION
On Windows, we were using back slashes, which meant `dlopen` failed to resolve all but trivial paths at runtime.