### PR TITLE
Update to upstream cypython branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "cpython"]
         path = cpython
-        url = https://github.com/dicej/cpython
+        url = https://github.com/python/cpython
+        branch = 3.12

--- a/runtime/pyo3-config-clippy.txt
+++ b/runtime/pyo3-config-clippy.txt
@@ -1,8 +1,8 @@
 implementation=CPython
-version=3.11
+version=3.12
 shared=false
 abi3=false
-lib_name=python3.11
+lib_name=python3.12
 pointer_width=64
 build_flags=
 suppress_build_script_link_lines=false


### PR DESCRIPTION
Since it seems there is not a need for a branch on your fork, I thought it might be nice to pin instead to one of the version branches in the upstream repository.

Still to do: I think we might need to update the CI cache key to the current commit hash of the submodule.. but I might need to think about how best to do that, and wanted to run the idea of moving to upstream first.
