### PR TITLE
update and fix examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -9,16 +9,16 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 
 ## Prerequisites
 
-* `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.15.0
+* `Wasmtime` 26.0.0 or later
+* `componentize-py` 0.15.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
-https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
+https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
-cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.15.0
+cargo install --version 26.0.0 wasmtime-cli
+pip install componentize-py==0.15.1
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -9,16 +9,16 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 
 ## Prerequisites
 
-* `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.15.0
+* `Wasmtime` 26.0.0 or later
+* `componentize-py` 0.15.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
-https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
+https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
-cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.15.0
+cargo install --version 26.0.0 wasmtime-cli
+pip install componentize-py==0.15.1
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -10,8 +10,8 @@ within a guest component.
 
 ## Prerequisites
 
-* `wasmtime` 18.0.0 or later
-* `componentize-py` 0.15.0
+* `wasmtime` 26.0.0 or later
+* `componentize-py` 0.15.1
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -19,11 +19,11 @@ not yet publish WASI builds.
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
-https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
+https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
-cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.15.0
+cargo install --version 26.0.0 wasmtime-cli
+pip install componentize-py==0.15.1
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -7,11 +7,11 @@ sandboxed Python code snippets from within a Python app.
 
 ## Prerequisites
 
-* `wasmtime-py` 18.0.0 or later
-* `componentize-py` 0.15.0
+* `wasmtime-py` 25.0.0 or later
+* `componentize-py` 0.15.1
 
 ```
-pip install componentize-py==0.15.0 wasmtime==18.0.2
+pip install componentize-py==0.15.1 wasmtime==25.0.0
 ```
 
 ## Running the demo

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -10,16 +10,16 @@ making an outbound TCP request using `wasi-sockets`.
 
 ## Prerequisites
 
-* `Wasmtime` 18.0.0 or later
-* `componentize-py` 0.15.0
+* `Wasmtime` 26.0.0 or later
+* `componentize-py` 0.15.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
-https://github.com/bytecodealliance/wasmtime/releases/tag/v18.0.0.
+https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
-cargo install --version 18.0.0 wasmtime-cli
-pip install componentize-py==0.15.0
+cargo install --version 26.0.0 wasmtime-cli
+pip install componentize-py==0.15.1
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.15.0"
+version = "0.15.1"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
An earlier commit which updated various dependencies (most notably, Wasmtime) unmasked a bug in `add_wasi_and_stubs` such that we were overwriting the host functions added by `wasmtime-wasi` with trapping stubs.  This wasn't a problem previously because there was only one version of WASIp2: 0.2.0.  Now that we have 0.2.1, 0.2.2, etc., with corresponding support in Wasmtime, we need to be a bit more careful.