### PR TITLE
Unsigned Integer Handling

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -554,8 +554,18 @@ pub extern "C" fn componentize_py_to_canon_i32(_py: &Python, value: Borrowed<PyA
     value.extract().unwrap()
 }
 
+#[export_name = "componentize-py#ToCanonU32"]
+pub extern "C" fn componentize_py_to_canon_u32(_py: &Python, value: Borrowed<PyAny>) -> u32 {
+    value.extract().unwrap()
+}
+
 #[export_name = "componentize-py#ToCanonI64"]
 pub extern "C" fn componentize_py_to_canon_i64(_py: &Python, value: Borrowed<PyAny>) -> i64 {
+    value.extract().unwrap()
+}
+
+#[export_name = "componentize-py#ToCanonU64"]
+pub extern "C" fn componentize_py_to_canon_u64(_py: &Python, value: Borrowed<PyAny>) -> u64 {
     value.extract().unwrap()
 }
 
@@ -730,8 +740,18 @@ pub extern "C" fn componentize_py_from_canon_i32(py: &Python, value: i32) -> Py<
     value.to_object(*py)
 }
 
+#[export_name = "componentize-py#FromCanonU32"]
+pub extern "C" fn componentize_py_from_canon_u32(py: &Python, value: u32) -> Py<PyAny> {
+    value.to_object(*py)
+}
+
 #[export_name = "componentize-py#FromCanonI64"]
 pub extern "C" fn componentize_py_from_canon_i64(py: &Python, value: i64) -> Py<PyAny> {
+    value.to_object(*py)
+}
+
+#[export_name = "componentize-py#FromCanonU64"]
+pub extern "C" fn componentize_py_from_canon_u64(py: &Python, value: u64) -> Py<PyAny> {
     value.to_object(*py)
 }
 

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -48,7 +48,17 @@ pub static IMPORT_SIGNATURES: &[(&str, &[ValType], &[ValType])] = &[
         &[ValType::I32],
     ),
     (
+        "componentize-py#ToCanonU32",
+        &[ValType::I32; 2],
+        &[ValType::I32],
+    ),
+    (
         "componentize-py#ToCanonI64",
+        &[ValType::I32; 2],
+        &[ValType::I64],
+    ),
+    (
+        "componentize-py#ToCanonU64",
         &[ValType::I32; 2],
         &[ValType::I64],
     ),
@@ -94,7 +104,17 @@ pub static IMPORT_SIGNATURES: &[(&str, &[ValType], &[ValType])] = &[
         &[ValType::I32],
     ),
     (
+        "componentize-py#FromCanonU32",
+        &[ValType::I32; 2],
+        &[ValType::I32],
+    ),
+    (
         "componentize-py#FromCanonI64",
+        &[ValType::I32, ValType::I64],
+        &[ValType::I32],
+    ),
+    (
+        "componentize-py#FromCanonU64",
         &[ValType::I32, ValType::I64],
         &[ValType::I32],
     ),
@@ -592,18 +612,32 @@ impl<'a> FunctionBindgen<'a> {
                     *IMPORTS.get("componentize-py#ToCanonBool").unwrap(),
                 ));
             }
-            Type::U8 | Type::U16 | Type::U32 | Type::S8 | Type::S16 | Type::S32 => {
+            Type::S8 | Type::S16 | Type::S32 => {
                 self.push(Ins::LocalGet(context));
                 self.push(Ins::LocalGet(value));
                 self.push(Ins::Call(
                     *IMPORTS.get("componentize-py#ToCanonI32").unwrap(),
                 ));
             }
-            Type::U64 | Type::S64 => {
+            Type::U8 | Type::U16 | Type::U32 => {
+                self.push(Ins::LocalGet(context));
+                self.push(Ins::LocalGet(value));
+                self.push(Ins::Call(
+                    *IMPORTS.get("componentize-py#ToCanonU32").unwrap(),
+                ));
+            }
+            Type::S64 => {
                 self.push(Ins::LocalGet(context));
                 self.push(Ins::LocalGet(value));
                 self.push(Ins::Call(
                     *IMPORTS.get("componentize-py#ToCanonI64").unwrap(),
+                ));
+            }
+            Type::U64 => {
+                self.push(Ins::LocalGet(context));
+                self.push(Ins::LocalGet(value));
+                self.push(Ins::Call(
+                    *IMPORTS.get("componentize-py#ToCanonU64").unwrap(),
                 ));
             }
             Type::F32 => {
@@ -1417,18 +1451,32 @@ impl<'a> FunctionBindgen<'a> {
                     *IMPORTS.get("componentize-py#FromCanonBool").unwrap(),
                 ));
             }
-            Type::U8 | Type::U16 | Type::U32 | Type::S8 | Type::S16 | Type::S32 => {
+            Type::S8 | Type::S16 | Type::S32 => {
                 self.push(Ins::LocalGet(context));
                 self.push(Ins::LocalGet(value[0]));
                 self.push(Ins::Call(
                     *IMPORTS.get("componentize-py#FromCanonI32").unwrap(),
                 ));
             }
-            Type::U64 | Type::S64 => {
+            Type::U8 | Type::U16 | Type::U32 => {
+                self.push(Ins::LocalGet(context));
+                self.push(Ins::LocalGet(value[0]));
+                self.push(Ins::Call(
+                    *IMPORTS.get("componentize-py#FromCanonU32").unwrap(),
+                ));
+            }
+            Type::S64 => {
                 self.push(Ins::LocalGet(context));
                 self.push(Ins::LocalGet(value[0]));
                 self.push(Ins::Call(
                     *IMPORTS.get("componentize-py#FromCanonI64").unwrap(),
+                ));
+            }
+            Type::U64 => {
+                self.push(Ins::LocalGet(context));
+                self.push(Ins::LocalGet(value[0]));
+                self.push(Ins::Call(
+                    *IMPORTS.get("componentize-py#FromCanonU64").unwrap(),
                 ));
             }
             Type::F32 => {

--- a/src/test/echoes.rs
+++ b/src/test/echoes.rs
@@ -216,18 +216,21 @@ class Echoes(exports.Echoes):
         return echoes.echo_bool(v)
 
     def echo_u8(self, v):
+        assert v >= 0
         return echoes.echo_u8(v)
 
     def echo_s8(self, v):
         return echoes.echo_s8(v)
 
     def echo_u16(self, v):
+        assert v >= 0
         return echoes.echo_u16(v)
 
     def echo_s16(self, v):
         return echoes.echo_s16(v)
 
     def echo_u32(self, v):
+        assert v >= 0
         return echoes.echo_u32(v)
 
     def echo_s32(self, v):
@@ -237,6 +240,7 @@ class Echoes(exports.Echoes):
         return echoes.echo_char(v)
 
     def echo_u64(self, v):
+        assert v >= 0
         return echoes.echo_u64(v)
 
     def echo_s64(self, v):
@@ -255,18 +259,21 @@ class Echoes(exports.Echoes):
         return echoes.echo_list_bool(v)
 
     def echo_list_u8(self, v):
+        assert all([n >= 0 for n in v])
         return echoes.echo_list_u8(v)
 
     def echo_list_s8(self, v):
         return echoes.echo_list_s8(v)
 
     def echo_list_u16(self, v):
+        assert all([n >= 0 for n in v])
         return echoes.echo_list_u16(v)
 
     def echo_list_s16(self, v):
         return echoes.echo_list_s16(v)
 
     def echo_list_u32(self, v):
+        assert all([n >= 0 for n in v])
         return echoes.echo_list_u32(v)
 
     def echo_list_s32(self, v):
@@ -276,6 +283,7 @@ class Echoes(exports.Echoes):
         return echoes.echo_list_char(v)
 
     def echo_list_u64(self, v):
+        assert all([n >= 0 for n in v])
         return echoes.echo_list_u64(v)
 
     def echo_list_s64(self, v):


### PR DESCRIPTION
When passing u64, u32, u16 or u8 values between rust and python the runtime incorrectly handles them as the equivalent signed type which leads to overflows for extreme values. This change adds explicit handling for unsigned types. 

I believe this wasn't being caught by the existing tests because the overflow was symmetric in each direction so values would overflow when passed from rust->python and then overflow again when passed in the opposite direction, returning to the initial value. Since the only check being done was that the value returned from the round trip unchanged the tests did not see this happening. This change adds a check in the python guest code which asserts that values which are expected to be unsigned are actually non-negative.

fixes #125