### PR TITLE
optionally override module names; bump version to 0.16.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,59 @@ env:
   WASI_SDK_RELEASE: wasi-sockets-alpha-5
 
 jobs:
+  linux:
+    name: Populate cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install latest Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-wasip1 wasm32-unknown-unknown
+
+      - name: Install latest Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1 wasm32-unknown-unknown
+          components: clippy, rustfmt
+
+      - name: Install Rust std source
+        shell: bash
+        run: rustup component add rust-src --toolchain nightly
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache-${{ hashFiles('./Cargo.lock') }}"
+          cache-on-failure: false
+
+      - name: Install WASI-SDK
+        shell: bash
+        run: |
+          cd /tmp
+          curl -LO https://github.com/dicej/wasi-sdk/releases/download/${WASI_SDK_RELEASE}/wasi-sdk-${WASI_SDK_VERSION}-linux.tar.gz
+          tar xf wasi-sdk-${WASI_SDK_VERSION}-linux.tar.gz
+          mv wasi-sdk-${WASI_SDK_VERSION} /opt/wasi-sdk
+
+      - name: Cache CPython
+        id: cache-cpython-wasi
+        uses: actions/cache@v4
+        with:
+          path: cpython/builddir/wasi
+          key: cpython-wasi
+          enableCrossOsArchive: true
+
+      - name: Build
+        shell: bash
+        run: cargo build --release
+
   test:
     name: Test
     strategy:
@@ -67,9 +120,9 @@ jobs:
         shell: bash
         run: echo "WASI_SDK_PATH=$(cygpath -m /tmp/wasi-sdk-${WASI_SDK_VERSION})" >> ${GITHUB_ENV}
 
-      - name: Cache CPython
+      - name: Restore CPython
         id: cache-cpython-wasi
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: cpython/builddir/wasi
           key: cpython-wasi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.15.2
+* `componentize-py` 0.16.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.15.2
+pip install componentize-py==0.16.0
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.15.2
+* `componentize-py` 0.16.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.15.2
+pip install componentize-py==0.16.0
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 26.0.0 or later
-* `componentize-py` 0.15.2
+* `componentize-py` 0.16.0
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.15.2
+pip install componentize-py==0.16.0
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -8,10 +8,10 @@ sandboxed Python code snippets from within a Python app.
 ## Prerequisites
 
 * `wasmtime-py` 25.0.0 or later
-* `componentize-py` 0.15.2
+* `componentize-py` 0.16.0
 
 ```
-pip install componentize-py==0.15.2 wasmtime==25.0.0
+pip install componentize-py==0.16.0 wasmtime==25.0.0
 ```
 
 ## Running the demo

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -11,7 +11,7 @@ making an outbound TCP request using `wasi-sockets`.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.15.2
+* `componentize-py` 0.16.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.15.2
+pip install componentize-py==0.16.0
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.15.2"
+version = "0.16.0"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/prelink.rs
+++ b/src/prelink.rs
@@ -50,7 +50,7 @@ pub fn embedded_helper_utils() -> Result<TempDir, io::Error> {
 }
 
 pub fn bundle_libraries(
-    library_path: Vec<(&str, Vec<std::path::PathBuf>)>,
+    library_path: Vec<(&str, Vec<PathBuf>)>,
 ) -> Result<Vec<Library>, anyhow::Error> {
     let mut libraries = vec![
         Library {
@@ -153,9 +153,8 @@ pub fn search_for_libraries_and_configs<'a>(
     module_worlds: &'a [(&'a str, &'a str)],
     world: Option<&'a str>,
 ) -> Result<(ConfigsMatchedWorlds<'a>, Vec<Library>), anyhow::Error> {
-    let mut raw_configs: Vec<crate::ConfigContext<crate::RawComponentizePyConfig>> = Vec::new();
-    let mut library_path: Vec<(&str, Vec<std::path::PathBuf>)> =
-        Vec::with_capacity(python_path.len());
+    let mut raw_configs: Vec<ConfigContext<RawComponentizePyConfig>> = Vec::new();
+    let mut library_path: Vec<(&str, Vec<PathBuf>)> = Vec::with_capacity(python_path.len());
     for path in python_path {
         let mut libraries = Vec::new();
         search_directory(

--- a/src/python.rs
+++ b/src/python.rs
@@ -12,7 +12,7 @@ use {
 #[allow(clippy::too_many_arguments)]
 #[pyo3::pyfunction]
 #[pyo3(name = "componentize")]
-#[pyo3(signature = (wit_path, world, features, all_features, python_path, module_worlds, app_name, output_path, stub_wasi))]
+#[pyo3(signature = (wit_path, world, features, all_features, python_path, module_worlds, app_name, output_path, stub_wasi, import_interface_names, export_interface_names))]
 fn python_componentize(
     wit_path: Option<PathBuf>,
     world: Option<&str>,
@@ -23,6 +23,8 @@ fn python_componentize(
     app_name: &str,
     output_path: PathBuf,
     stub_wasi: bool,
+    import_interface_names: Vec<(PyBackedStr, PyBackedStr)>,
+    export_interface_names: Vec<(PyBackedStr, PyBackedStr)>,
 ) -> PyResult<()> {
     (|| {
         Runtime::new()?.block_on(crate::componentize(
@@ -39,14 +41,23 @@ fn python_componentize(
             &output_path,
             None,
             stub_wasi,
+            &import_interface_names
+                .iter()
+                .map(|(a, b)| (a.as_ref(), b.as_ref()))
+                .collect(),
+            &export_interface_names
+                .iter()
+                .map(|(a, b)| (a.as_ref(), b.as_ref()))
+                .collect(),
         ))
     })()
     .map_err(|e| PyAssertionError::new_err(format!("{e:?}")))
 }
 
+#[allow(clippy::too_many_arguments)]
 #[pyo3::pyfunction]
 #[pyo3(name = "generate_bindings")]
-#[pyo3(signature = (wit_path, world, features, all_features, world_module, output_dir))]
+#[pyo3(signature = (wit_path, world, features, all_features, world_module, output_dir, import_interface_names, export_interface_names))]
 fn python_generate_bindings(
     wit_path: PathBuf,
     world: Option<&str>,
@@ -54,6 +65,8 @@ fn python_generate_bindings(
     all_features: bool,
     world_module: Option<&str>,
     output_dir: PathBuf,
+    import_interface_names: Vec<(PyBackedStr, PyBackedStr)>,
+    export_interface_names: Vec<(PyBackedStr, PyBackedStr)>,
 ) -> PyResult<()> {
     crate::generate_bindings(
         &wit_path,
@@ -62,6 +75,14 @@ fn python_generate_bindings(
         all_features,
         world_module,
         &output_dir,
+        &import_interface_names
+            .iter()
+            .map(|(a, b)| (a.as_ref(), b.as_ref()))
+            .collect(),
+        &export_interface_names
+            .iter()
+            .map(|(a, b)| (a.as_ref(), b.as_ref()))
+            .collect(),
     )
     .map_err(|e| PyAssertionError::new_err(format!("{e:?}")))
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@ use {
         prelude::Strategy,
         test_runner::{self, TestRng, TestRunner},
     },
-    std::{env, fs, iter, marker::PhantomData},
+    std::{collections::HashMap, env, fs, iter, marker::PhantomData},
     tokio::runtime::Runtime,
     wasmtime::{
         component::{Component, InstancePre, Linker, ResourceTable},
@@ -77,6 +77,8 @@ async fn make_component(
         &tempdir.path().join("app.wasm"),
         add_to_linker,
         false,
+        &HashMap::new(),
+        &HashMap::new(),
     )
     .await?;
 


### PR DESCRIPTION
This adds CLI and componentize-py.toml options for overriding the generated Python module names for one or more WIT interfaces.

By default, the name is the snake-case version of the WIT name, qualified as necessary with the package namespace and name and/or the version in cases of ambiguity.  Sometimes that's not what you want, though, so now you can override the naming on an individual basis as long as the name(s) you pick are unique.

This can be especially useful for backwards compatibility when adding new versions of WIT interfaces.  In that case, the generated module name may go from unqualified to qualified, but you can now force the name of the original version to be unqualified for compatibility.  For example:

- You release an SDK with an interface called `foo:bar/baz@1.0.0`.  Since that's the only interface with the name `baz`, `componentize-py` will name the generated module `baz` also.

- Later, you release a new version of the SDK with support for _both_ `foo:bar/baz@1.0.0` _and_ `foo:bar/baz@2.0.0`.  In that case, `componentize-py` will name the generated modules `foo_bar_baz_1_0_0` and `foo_bar_baz_2_0_0` by default.  However, you don't want to force users of your SDK to use the new name, so you pass `--import-interface-name foo:bar/baz@1.0.0=baz` to `componentize-py`, which tells it to use the original name.