### PR TITLE
On Windows, do not require redist of vcruntime DLL

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
The Rancher Desktop folks are looking to bundle some Wasm developer tooling.  However, they cannot redistribute the vcruntime DLL on Windows for licensing reasons, and therefore prefer Windows builds in the toolchain to link the CRT statically instead of dynamically.

This PR uses a solution that's worked elsewhere; happy to do it a different way if preferred.
