### PR TITLE
declare world-level type exports before function imports

### DIFF
--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1986,8 +1986,8 @@ from ..types import Result, Ok, Err, Some
                 "{docs}{python_imports}
 from .types import Result, Ok, Err, Some
 {imports}
-{function_imports}
 {type_exports}
+{function_imports}
 {protocol}
 "
             )?;

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -57,6 +57,13 @@ pub struct ThingList(Vec<u8>);
 pub struct ThingString(String);
 pub struct MyFloat(f64);
 
+#[async_trait]
+impl TestsImports for Ctx {
+    async fn output(&mut self, _: Frame) -> Result<()> {
+        unreachable!()
+    }
+}
+
 macro_rules! load_guest_code {
     ($($input_string:expr),*) => {
         &[

--- a/src/test/wit/tests.wit
+++ b/src/test/wit/tests.wit
@@ -179,4 +179,10 @@ world tests {
   export add: func(a: borrow<float>, b: borrow<float>) -> own<float>;
 
   export read-file: func(path: string) -> result<list<u8>, string>;
+
+  record frame {
+    id: s32,
+  }
+
+  import output: func(frame: frame);
 }


### PR DESCRIPTION
This avoids a declaration ordering issue if an imported function refers to an exported type (e.g. as a parameter or result type).

Fixes #134