### PR TITLE
Fix clippy lint for iter::repeat_n

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,7 @@ jobs:
 
   test:
     name: Test
+    needs: linux
     strategy:
       fail-fast: false
       matrix:

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,7 +29,7 @@ impl Types for Flags {
         match self.repr() {
             FlagsRepr::U8 => Box::new(iter::once(Type::U8)),
             FlagsRepr::U16 => Box::new(iter::once(Type::U16)),
-            FlagsRepr::U32(count) => Box::new(iter::repeat(Type::U32).take(count)),
+            FlagsRepr::U32(count) => Box::new(std::iter::repeat_n(Type::U32, count)),
         }
     }
 }


### PR DESCRIPTION
This was flagged in the latest rust version.
