### PR TITLE
use "wit_world" module name by default for generated bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Then, use the `hello` module produced by the command above to write your app:
 
 ```shell
 cat >app.py <<EOF
-import hello
-class Hello(hello.Hello):
+import wit_world
+class WitWorld(wit_world.WitWorld):
     def hello(self) -> str:
         return "Hello, World!"
 EOF

--- a/bundled/poll_loop.py
+++ b/bundled/poll_loop.py
@@ -11,16 +11,16 @@ import asyncio
 import socket
 import subprocess
 
-from proxy.types import Ok, Err
-from proxy.imports import types, streams, poll, outgoing_handler
-from proxy.imports.types import (
+from wit_world.types import Ok, Err
+from wit_world.imports import types, streams, poll, outgoing_handler
+from wit_world.imports.types import (
     IncomingBody,
     OutgoingBody,
     OutgoingRequest,
     IncomingResponse,
 )
-from proxy.imports.streams import StreamError_Closed, InputStream
-from proxy.imports.poll import Pollable
+from wit_world.imports.streams import StreamError_Closed, InputStream
+from wit_world.imports.poll import Pollable
 from typing import Optional, cast
 
 # Maximum number of bytes to read at a time

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.16.0
+* `componentize-py` 0.17.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.16.0
+pip install componentize-py==0.17.0
 ```
 
 ## Running the demo

--- a/examples/cli/app.py
+++ b/examples/cli/app.py
@@ -1,6 +1,9 @@
-from command import exports
-
+from wit_world import exports
+from wit_world.imports.environment import get_arguments
+import pdb
 
 class Run(exports.Run):
     def run(self) -> None:
+        if "--pdb" in get_arguments():
+            pdb.set_trace()
         print("Hello, world!")

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.16.0
+* `componentize-py` 0.17.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.16.0
+pip install componentize-py==0.17.0
 ```
 
 ## Running the demo

--- a/examples/http/app.py
+++ b/examples/http/app.py
@@ -9,10 +9,10 @@ import asyncio
 import hashlib
 import poll_loop
 
-from proxy import exports
-from proxy.types import Ok
-from proxy.imports import types
-from proxy.imports.types import (
+from wit_world import exports
+from wit_world.types import Ok
+from wit_world.imports import types
+from wit_world.imports.types import (
     Method_Get,
     Method_Post,
     Scheme,

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 26.0.0 or later
-* `componentize-py` 0.16.0
+* `componentize-py` 0.17.0
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.16.0
+pip install componentize-py==0.17.0
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/matrix-math/app.py
+++ b/examples/matrix-math/app.py
@@ -3,12 +3,12 @@
 
 import sys
 import numpy
-import matrix_math
-from matrix_math import exports
-from matrix_math.types import Err
+import wit_world
+from wit_world import exports
+from wit_world.types import Err
 
 
-class MatrixMath(matrix_math.MatrixMath):
+class WitWorld(wit_world.WitWorld):
     def multiply(self, a: list[list[float]], b: list[list[float]]) -> list[list[float]]:
         print(f"matrix_multiply received arguments {a} and {b}")
         return numpy.matmul(a, b).tolist()  # type: ignore
@@ -21,4 +21,4 @@ class Run(exports.Run):
             print("usage: matrix-math <matrix> <matrix>", file=sys.stderr)
             exit(-1)
 
-        print(MatrixMath().multiply(eval(args[0]), eval(args[1])))
+        print(WitWorld().multiply(eval(args[0]), eval(args[1])))

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -8,10 +8,10 @@ sandboxed Python code snippets from within a Python app.
 ## Prerequisites
 
 * `wasmtime-py` 25.0.0 or later
-* `componentize-py` 0.16.0
+* `componentize-py` 0.17.0
 
 ```
-pip install componentize-py==0.16.0 wasmtime==25.0.0
+pip install componentize-py==0.17.0 wasmtime==25.0.0
 ```
 
 ## Running the demo

--- a/examples/sandbox/guest.py
+++ b/examples/sandbox/guest.py
@@ -1,5 +1,5 @@
-import sandbox
-from sandbox.types import Err
+import wit_world
+from wit_world.types import Err
 import json
 
 
@@ -11,7 +11,7 @@ def handle(e: Exception) -> Err[str]:
         return Err(f"{type(e).__name__}: {message}")
 
 
-class Sandbox(sandbox.Sandbox):
+class WitWorld(wit_world.WitWorld):
     def eval(self, expression: str) -> str:
         try:
             return json.dumps(eval(expression))

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -11,7 +11,7 @@ making an outbound TCP request using `wasi-sockets`.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.16.0
+* `componentize-py` 0.17.0
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.16.0
+pip install componentize-py==0.17.0
 ```
 
 ## Running the demo

--- a/examples/tcp/app.py
+++ b/examples/tcp/app.py
@@ -2,7 +2,7 @@ import sys
 import asyncio
 import ipaddress
 from ipaddress import IPv4Address, IPv6Address
-from command import exports
+from wit_world import exports
 from typing import Tuple
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.16.0"
+version = "0.17.0"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -658,9 +658,7 @@ pub extern "C" fn componentize_py_get_field<'a>(
                 .nth(field)
                 .unwrap_or(0);
 
-            unsafe { mem::transmute::<u32, i32>(value) }
-                .to_object(*py)
-                .into_bound(*py)
+            u32::cast_signed(value).to_object(*py).into_bound(*py)
         }
         Type::Option => match i32::try_from(field).unwrap() {
             DISCRIMINANT_FIELD_INDEX => if value.is_none() { 0 } else { 1 }
@@ -865,7 +863,7 @@ pub unsafe extern "C" fn componentize_py_init<'a>(
                         slice::from_raw_parts(data, len)
                             .iter()
                             .map(|v| {
-                                mem::transmute::<i32, u32>(
+                                i32::cast_unsigned(
                                     Bound::from_borrowed_ptr(*py, v.as_ptr()).extract().unwrap(),
                                 )
                             })

--- a/src/command.rs
+++ b/src/command.rs
@@ -66,6 +66,12 @@ pub struct Common {
     /// name.
     #[arg(long, value_parser = parse_key_value)]
     pub export_interface_name: Vec<(String, String)>,
+
+    /// Optional name of top-level module to use for bindings.
+    ///
+    /// If this is not specified, the module name will default to "wit_world".
+    #[arg(long)]
+    pub world_module: Option<String>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -126,12 +132,6 @@ pub struct Bindings {
     ///
     /// This will be created if it does not already exist.
     pub output_dir: PathBuf,
-
-    /// Optional name of top-level module to use for bindings.
-    ///
-    /// If this is not specified, the module name will be derived from the world name.
-    #[arg(long)]
-    pub world_module: Option<String>,
 }
 
 fn parse_key_value(s: &str) -> Result<(String, String), String> {
@@ -157,7 +157,7 @@ fn generate_bindings(common: Common, bindings: Bindings) -> Result<()> {
         common.world.as_deref(),
         &common.features,
         common.all_features,
-        bindings.world_module.as_deref(),
+        common.world_module.as_deref(),
         &bindings.output_dir,
         &common
             .import_interface_name
@@ -189,6 +189,7 @@ fn componentize(common: Common, componentize: Componentize) -> Result<()> {
         common.world.as_deref(),
         &common.features,
         common.all_features,
+        common.world_module.as_deref(),
         &python_path.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
         &componentize
             .module_worlds
@@ -339,6 +340,7 @@ mod tests {
         let common = Common {
             wit_path: Some(wit.path().into()),
             world: None,
+            world_module: Some("bindings".into()),
             quiet: false,
             features: vec![],
             all_features: false,
@@ -347,7 +349,6 @@ mod tests {
         };
         let bindings = Bindings {
             output_dir: out_dir.path().into(),
-            world_module: None,
         };
         generate_bindings(common, bindings)?;
 
@@ -369,6 +370,7 @@ mod tests {
         let common = Common {
             wit_path: Some(wit.path().into()),
             world: None,
+            world_module: Some("bindings".into()),
             quiet: false,
             features: vec!["x".to_owned()],
             all_features: false,
@@ -377,7 +379,6 @@ mod tests {
         };
         let bindings = Bindings {
             output_dir: out_dir.path().into(),
-            world_module: None,
         };
         generate_bindings(common, bindings)?;
 
@@ -399,6 +400,7 @@ mod tests {
         let common = Common {
             wit_path: Some(wit.path().into()),
             world: None,
+            world_module: Some("bindings".into()),
             quiet: false,
             features: vec![],
             all_features: true,
@@ -407,7 +409,6 @@ mod tests {
         };
         let bindings = Bindings {
             output_dir: out_dir.path().into(),
-            world_module: None,
         };
         generate_bindings(common, bindings)?;
 
@@ -427,6 +428,7 @@ mod tests {
         let common = Common {
             wit_path: Some(wit.path().into()),
             world: None,
+            world_module: Some("bindings".into()),
             quiet: false,
             features: vec!["x".to_owned()],
             all_features: false,
@@ -435,7 +437,6 @@ mod tests {
         };
         let bindings = Bindings {
             output_dir: out_dir.path().into(),
-            world_module: None,
         };
         generate_bindings(common.clone(), bindings)?;
         fs::write(

--- a/src/python.rs
+++ b/src/python.rs
@@ -17,12 +17,13 @@ use {
 #[allow(clippy::too_many_arguments)]
 #[pyo3::pyfunction]
 #[pyo3(name = "componentize")]
-#[pyo3(signature = (wit_path, world, features, all_features, python_path, module_worlds, app_name, output_path, stub_wasi, import_interface_names, export_interface_names))]
+#[pyo3(signature = (wit_path, world, features, all_features, world_module, python_path, module_worlds, app_name, output_path, stub_wasi, import_interface_names, export_interface_names))]
 fn python_componentize(
     wit_path: Option<PathBuf>,
     world: Option<&str>,
     features: Vec<String>,
     all_features: bool,
+    world_module: Option<&str>,
     python_path: Vec<PyBackedStr>,
     module_worlds: Vec<(PyBackedStr, PyBackedStr)>,
     app_name: &str,
@@ -37,6 +38,7 @@ fn python_componentize(
             world,
             &features,
             all_features,
+            world_module,
             &python_path.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
             &module_worlds
                 .iter()

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1945,10 +1945,7 @@ from ..types import Result, Ok, Err, Some
             let mut file = File::create(path.join("__init__.py"))?;
             let function_imports = world_imports.functions.concat();
             let type_exports = world_exports.types.concat();
-            let camel = self.resolve.worlds[world]
-                .name
-                .to_upper_camel_case()
-                .escape();
+            let camel = world_module.to_upper_camel_case().escape();
 
             let protocol = if let Some(alias_module) = world_exports.alias_module {
                 format!("{camel} = {alias_module}.{camel}")

--- a/src/test.rs
+++ b/src/test.rs
@@ -45,6 +45,7 @@ static ENGINE: Lazy<Engine> = Lazy::new(|| {
 #[allow(clippy::type_complexity)]
 async fn make_component(
     wit: &str,
+    world_module: Option<&str>,
     guest_code: &[(&str, &str)],
     python_path: &[&str],
     module_worlds: &[(&str, &str)],
@@ -64,6 +65,7 @@ async fn make_component(
         None,
         &[],
         false,
+        world_module,
         &python_path
             .iter()
             .copied()
@@ -119,6 +121,7 @@ struct Tester<H> {
 impl<H: Host> Tester<H> {
     fn new(
         wit: &str,
+        world_module: Option<&str>,
         guest_code: &[(&str, &str)],
         python_path: &[&str],
         module_worlds: &[(&str, &str)],
@@ -129,6 +132,7 @@ impl<H: Host> Tester<H> {
         // would slow it down a lot).  This will help exercise the stub mechanism when pre-initializing.
         let component = &Runtime::new()?.block_on(make_component(
             wit,
+            world_module,
             guest_code,
             python_path,
             module_worlds,

--- a/src/test/echoes.rs
+++ b/src/test/echoes.rs
@@ -313,7 +313,15 @@ class Echoes(exports.Echoes):
 )];
 
 static TESTER: Lazy<Tester<Host>> = Lazy::new(|| {
-    Tester::<Host>::new(include_str!("wit/echoes.wit"), GUEST_CODE, &[], &[], *SEED).unwrap()
+    Tester::<Host>::new(
+        include_str!("wit/echoes.wit"),
+        Some("echoes_test"),
+        GUEST_CODE,
+        &[],
+        &[],
+        *SEED,
+    )
+    .unwrap()
 });
 
 #[test]

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -135,6 +135,7 @@ impl super::Host for BarHost {
 static TESTER: Lazy<Tester<Host>> = Lazy::new(|| {
     Tester::<Host>::new(
         include_str!("wit/tests.wit"),
+        Some("tests"),
         GUEST_CODE,
         &["src/test"],
         &[("foo_sdk", "foo-world"), ("bar_sdk", "bar-world")],

--- a/test-generator/src/lib.rs
+++ b/test-generator/src/lib.rs
@@ -859,7 +859,14 @@ class EchoesGenerated(exports.EchoesGenerated):
 )];
 
 static TESTER: Lazy<Tester<Host>> = Lazy::new(|| {{
-    Tester::<Host>::new(include_str!({wit_path:?}), GUEST_CODE, &[], &[], *SEED).unwrap()
+    Tester::<Host>::new(
+        include_str!({wit_path:?}),
+        Some("echoes_generated_test"),
+        GUEST_CODE,
+        &[],
+        &[],
+        *SEED
+    ).unwrap()
 }});
 
 {test_functions}

--- a/tests/bindings.rs
+++ b/tests/bindings.rs
@@ -21,7 +21,7 @@ fn lint_cli_bindings() -> anyhow::Result<()> {
 
     generate_bindings(&path, "wasi:cli/command@0.2.0")?;
 
-    assert!(predicate::path::is_dir().eval(&path.join("command")));
+    assert!(predicate::path::is_dir().eval(&path.join("wit_world")));
 
     mypy_check(&path, ["--strict", "."]);
 
@@ -40,7 +40,7 @@ fn lint_http_bindings() -> anyhow::Result<()> {
 
     generate_bindings(&path, "wasi:http/proxy@0.2.0")?;
 
-    assert!(predicate::path::is_dir().eval(&path.join("proxy")));
+    assert!(predicate::path::is_dir().eval(&path.join("wit_world")));
 
     mypy_check(
         &path,
@@ -51,7 +51,7 @@ fn lint_http_bindings() -> anyhow::Result<()> {
             "-m",
             "app",
             "-p",
-            "proxy",
+            "wit_world",
         ],
     );
 
@@ -72,7 +72,7 @@ fn lint_matrix_math_bindings() -> anyhow::Result<()> {
 
     generate_bindings(&path, "matrix-math")?;
 
-    assert!(predicate::path::is_dir().eval(&path.join("matrix_math")));
+    assert!(predicate::path::is_dir().eval(&path.join("wit_world")));
 
     mypy_check(
         &path,
@@ -84,7 +84,7 @@ fn lint_matrix_math_bindings() -> anyhow::Result<()> {
             "-m",
             "app",
             "-p",
-            "matrix_math",
+            "wit_world",
         ],
     );
 
@@ -103,9 +103,9 @@ fn lint_sandbox_bindings() -> anyhow::Result<()> {
         .assert()
         .success();
 
-    assert!(predicate::path::is_dir().eval(&path.join("sandbox")));
+    assert!(predicate::path::is_dir().eval(&path.join("wit_world")));
 
-    mypy_check(&path, ["--strict", "-m", "guest", "-p", "sandbox"]);
+    mypy_check(&path, ["--strict", "-m", "guest", "-p", "wit_world"]);
 
     Ok(())
 }
@@ -122,7 +122,7 @@ fn lint_tcp_bindings() -> anyhow::Result<()> {
 
     generate_bindings(&path, "wasi:cli/command@0.2.0")?;
 
-    assert!(predicate::path::is_dir().eval(&path.join("command")));
+    assert!(predicate::path::is_dir().eval(&path.join("wit_world")));
 
     mypy_check(&path, ["--strict", "."]);
 


### PR DESCRIPTION
Previously, we used a name derived from the WIT world name, but this is more predictable.  It can be overridden using the `--world-module` option, which now applies to both the `bindings` and `componentize` subcommands.

I've also bumped the version to 0.17.0 since this is a breaking change.

Fixes #149