### PR TITLE
fix memory leaks in generated bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "target-lexicon 0.13.2",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -681,7 +681,7 @@ dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.13.2",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -698,7 +698,7 @@ checksum = "7617f13f392ebb63c5126258aca8b8eca739636ca7e4eeee301d3eff68489a6a"
 dependencies = [
  "cranelift-codegen",
  "libc",
- "target-lexicon 0.13.2",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1849,11 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
+version = "0.25.0"
+source = "git+https://github.com/dicej/pyo3?branch=v0.25.0-no-wasm32-unwind#d0cf051de41c3cefeee95c9524aa460cde7e849d"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -1868,19 +1866,17 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
+version = "0.25.0"
+source = "git+https://github.com/dicej/pyo3?branch=v0.25.0-no-wasm32-unwind#d0cf051de41c3cefeee95c9524aa460cde7e849d"
 dependencies = [
  "once_cell",
- "target-lexicon 0.12.16",
+ "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
+version = "0.25.0"
+source = "git+https://github.com/dicej/pyo3?branch=v0.25.0-no-wasm32-unwind#d0cf051de41c3cefeee95c9524aa460cde7e849d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1888,9 +1884,8 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
+version = "0.25.0"
+source = "git+https://github.com/dicej/pyo3?branch=v0.25.0-no-wasm32-unwind#d0cf051de41c3cefeee95c9524aa460cde7e849d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1900,9 +1895,8 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
+version = "0.25.0"
+source = "git+https://github.com/dicej/pyo3?branch=v0.25.0-no-wasm32-unwind#d0cf051de41c3cefeee95c9524aa460cde7e849d"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2466,12 +2460,6 @@ dependencies = [
  "libc",
  "xattr",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-lexicon"
@@ -3062,7 +3050,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sptr",
- "target-lexicon 0.13.2",
+ "target-lexicon",
  "trait-variant",
  "wasm-encoder 0.224.1",
  "wasmparser 0.224.1",
@@ -3152,7 +3140,7 @@ dependencies = [
  "object",
  "pulley-interpreter",
  "smallvec",
- "target-lexicon 0.13.2",
+ "target-lexicon",
  "thiserror",
  "wasmparser 0.224.1",
  "wasmtime-environ",
@@ -3179,7 +3167,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "target-lexicon 0.13.2",
+ "target-lexicon",
  "wasm-encoder 0.224.1",
  "wasmparser 0.224.1",
  "wasmprinter",
@@ -3305,7 +3293,7 @@ dependencies = [
  "cranelift-codegen",
  "gimli",
  "object",
- "target-lexicon 0.13.2",
+ "target-lexicon",
  "wasmparser 0.224.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
@@ -3449,7 +3437,7 @@ dependencies = [
  "gimli",
  "regalloc2",
  "smallvec",
- "target-lexicon 0.13.2",
+ "target-lexicon",
  "thiserror",
  "wasmparser 0.224.1",
  "wasmtime-cranelift",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ wasmparser = "0.227.0"
 indexmap = "2.6.0"
 bincode = "1.3.3"
 heck = "0.5.0"
-pyo3 = { version = "0.22.5", features = [
+# TODO: switch back to upstream once we've updated to Python 3.14, at which
+# point the following patch will no longer be needed:
+pyo3 = { git = "https://github.com/dicej/pyo3", branch = "v0.25.0-no-wasm32-unwind", features = [
     "abi3-py39",
     "extension-module",
 ], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 exclude = ["cpython"]
 

--- a/build.rs
+++ b/build.rs
@@ -124,9 +124,12 @@ fn package_all_the_things(out_dir: &Path) -> Result<()> {
         }
     }
 
-    cmd.env("RUSTFLAGS", "-C relocation-model=pic")
-        .env("CARGO_TARGET_DIR", out_dir)
-        .env("PYO3_CONFIG_FILE", out_dir.join("pyo3-config.txt"));
+    cmd.env(
+        "RUSTFLAGS",
+        "-C relocation-model=pic --cfg pyo3_disable_reference_pool",
+    )
+    .env("CARGO_TARGET_DIR", out_dir)
+    .env("PYO3_CONFIG_FILE", out_dir.join("pyo3-config.txt"));
 
     let status = cmd.status()?;
     assert!(status.success());

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.17.0
+* `componentize-py` 0.17.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.17.0
+pip install componentize-py==0.17.1
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.17.0
+* `componentize-py` 0.17.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.17.0
+pip install componentize-py==0.17.1
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 26.0.0 or later
-* `componentize-py` 0.17.0
+* `componentize-py` 0.17.1
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.17.0
+pip install componentize-py==0.17.1
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.1/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -8,10 +8,10 @@ sandboxed Python code snippets from within a Python app.
 ## Prerequisites
 
 * `wasmtime-py` 25.0.0 or later
-* `componentize-py` 0.17.0
+* `componentize-py` 0.17.1
 
 ```
-pip install componentize-py==0.17.0 wasmtime==25.0.0
+pip install componentize-py==0.17.1 wasmtime==25.0.0
 ```
 
 ## Running the demo

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -11,7 +11,7 @@ making an outbound TCP request using `wasi-sockets`.
 ## Prerequisites
 
 * `Wasmtime` 26.0.0 or later
-* `componentize-py` 0.17.0
+* `componentize-py` 0.17.1
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v26.0.0.
 
 ```
 cargo install --version 26.0.0 wasmtime-cli
-pip install componentize-py==0.17.0
+pip install componentize-py==0.17.1
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.17.0"
+version = "0.17.1"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,7 +9,9 @@ crate-type = ["staticlib"]
 [dependencies]
 anyhow = "1.0.91"
 once_cell = "1.20.2"
-pyo3 = { version = "0.22.5", features = ["abi3-py312", "num-bigint"] }
+# TODO: switch back to upstream once we've updated to Python 3.14, at which
+# point the following patch will no longer be needed:
+pyo3 = { git = "https://github.com/dicej/pyo3", branch = "v0.25.0-no-wasm32-unwind", features = ["abi3-py312", "num-bigint"] }
 componentize-py-shared = { path = "../shared" }
 num-bigint = "0.4.6"
 wit-bindgen = { version = "0.40.0", default-features = false, features = ["macros", "realloc"] }

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -333,6 +333,7 @@ impl<'a> FunctionBindgen<'a> {
                 .collect::<Vec<_>>();
 
             self.from_canon_record(self.result.types(), context, &locals, output);
+            self.free_canon_record(self.result.types(), &locals);
 
             for (local, ty) in locals.iter().zip(&self.results_abi.flattened.clone()).rev() {
                 self.pop_local(*local, *ty);
@@ -344,6 +345,7 @@ impl<'a> FunctionBindgen<'a> {
             self.push(Ins::LocalSet(source));
 
             self.load_record(self.result.types(), context, source, output);
+            self.free_stored_record(self.result.types(), source);
 
             self.pop_local(source, ValType::I32);
             self.pop_stack(self.results_abi.size);

--- a/src/python.rs
+++ b/src/python.rs
@@ -98,7 +98,7 @@ fn python_generate_bindings(
 #[pyo3(name = "script")]
 fn python_script(py: Python) -> PyResult<()> {
     crate::command::run(
-        py.import_bound("sys")?
+        py.import("sys")?
             .getattr("argv")?
             .extract::<Vec<OsString>>()?,
     )

--- a/src/test/python_source/app.py
+++ b/src/test/python_source/app.py
@@ -134,6 +134,12 @@ class Tests(tests.Tests):
                 return f.read()
         except:
             raise Err(traceback.format_exc())
+
+    def test_refcounts(self):
+        # Retrieve 5GiB in chunks of 1MiB, which should _not_ lead to a
+        # `MemoryError` if we're handling refcounts correctly in the runtime.
+        for _ in range(5 * 1024):
+            chunk = tests.get_bytes(1024 * 1024)
    
 class FooInterface(foo_exports.FooInterface):
     def test(self, s: str) -> str:

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -60,6 +60,10 @@ impl TestsImports for Ctx {
     async fn output(&mut self, _: Frame) -> Result<()> {
         unreachable!()
     }
+
+    async fn get_bytes(&mut self, count: u32) -> Result<Vec<u8>> {
+        Ok(vec![42u8; usize::try_from(count).unwrap()])
+    }
 }
 
 macro_rules! load_guest_code {
@@ -248,6 +252,11 @@ fn resource_import_and_export() -> Result<()> {
             Ok(())
         })
     })
+}
+
+#[test]
+fn refcounts() -> Result<()> {
+    TESTER.test(|world, store, runtime| runtime.block_on(world.call_test_refcounts(store)))
 }
 
 #[test]

--- a/src/test/wit/tests.wit
+++ b/src/test/wit/tests.wit
@@ -180,9 +180,13 @@ world tests {
 
   export read-file: func(path: string) -> result<list<u8>, string>;
 
+  export test-refcounts: func();
+
   record frame {
     id: s32,
   }
 
   import output: func(frame: frame);
+
+  import get-bytes: func(count: u32) -> list<u8>;
 }


### PR DESCRIPTION
This addresses a couple of issues:

- We weren't freeing canonical ABI results after calling imports and then converting the results to Python values.

- We were using the PyO3 `Bound` APIs incorrectly in a few places, resulting in refcounts being incremented too many times.

While debugging the latter issue, I took the opportunity to update to the latest PyO3 release, which required addressing the usual API breakage.  It also required temporarily forking the repo to add a patch to disable `extern "C-unwind"` in `pyo3_ffi` on `wasm32`.  We should be able to drop that fork once we upgrade everything to Python 3.14.

Finally, I discovered
https://pyo3.rs/v0.25.0/features.html#pyo3_disable_reference_pool which supposedly optimizes Rust<->Python transitions by disabling a feature we don't rely on anyway, so I went ahead and enabled it.

Fixes #152