### PR TITLE
Fix test-generator feature dependency

### DIFF
--- a/test-generator/Cargo.toml
+++ b/test-generator/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.91"
-getrandom = "0.2.15"
+getrandom = { version = "0.2.15", features = ['std'] }
 hex = "0.4.3"
 proptest = "1.5.0"


### PR DESCRIPTION
Using `componentize-py` as a dependency from another project (following these instructions: https://github.com/bytecodealliance/componentize-py/issues/160), it fails to build with the following error:

```shell
Compiling componentize-py-shared v0.1.0 (/Users/mikkel/code/fermyon/componentize-py/shared)
error[E0277]: the trait bound `getrandom::Error: std::error::Error` is not satisfied
   --> /Users/mikkel/code/fermyon/componentize-py/test-generator/src/lib.rs:549:40
    |
549 |         getrandom::getrandom(&mut seed)?;
    |                                        ^ the trait `std::error::Error` is not implemented for `getrandom::Error`
    |
    = help: the trait `FromResidual<Result<Infallible, E>>` is implemented for `Result<T, F>`
    = note: required for `anyhow::Error` to implement `From<getrandom::Error>`
    = note: required for `Result<(), anyhow::Error>` to implement `FromResidual<Result<Infallible, getrandom::Error>>
```
Consulting with @alexcrichton (thank you) I got the following:

> This has to do with version/feature resolution in Rust where componentize-py has a Cargo.lock which uses one set of dependencies/versions but when you build externally you don't start with that so by default you pull in newer versions of dependencies. This uncovers a preexisting bug in componentize-py where it's accidentally relying on a crate feature being enabled for a crate without explicitly enabling it. That happens to work within componentize-py because some other crate enables the feature (somehow, transitively, etc) but doesn't work externally because nothing else enables it.

> The "true fix" is to change test-generator's dependency on getrandom to getrandom = { version = "0.2.15", features = ['std'] }. A "workaround fix" would be to add that dependency directive to your own Cargo.toml

I've validated the below fix in my instance of referencing `componentize-py` from another project.