### PR TITLE
feat: add support for multiple wit paths

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -24,9 +24,12 @@ pub struct Options {
 
 #[derive(clap::Args, Clone, Debug)]
 pub struct Common {
-    /// File or directory containing WIT document(s)
+    /// File or directory containing WIT document(s).
+    ///
+    /// This may be specified more than once, for example:
+    /// `-d ./wit/deps -d ./wit/app`
     #[arg(short = 'd', long)]
-    pub wit_path: Option<PathBuf>,
+    pub wit_path: Vec<PathBuf>,
 
     /// Name of world to target (or default world if `None`)
     #[arg(short = 'w', long)]
@@ -151,9 +154,7 @@ pub fn run<T: Into<OsString> + Clone, I: IntoIterator<Item = T>>(args: I) -> Res
 
 fn generate_bindings(common: Common, bindings: Bindings) -> Result<()> {
     crate::generate_bindings(
-        &common
-            .wit_path
-            .unwrap_or_else(|| Path::new("wit").to_owned()),
+        &common.wit_path,
         common.world.as_deref(),
         &common.features,
         common.all_features,
@@ -185,7 +186,7 @@ fn componentize(common: Common, componentize: Componentize) -> Result<()> {
     }
 
     Runtime::new()?.block_on(crate::componentize(
-        common.wit_path.as_deref(),
+        &common.wit_path,
         common.world.as_deref(),
         &common.features,
         common.all_features,
@@ -338,7 +339,7 @@ mod tests {
 
         // When generating the bindings for this WIT world
         let common = Common {
-            wit_path: Some(wit.path().into()),
+            wit_path: vec![wit.path().into()],
             world: None,
             world_module: Some("bindings".into()),
             quiet: false,
@@ -368,7 +369,7 @@ mod tests {
 
         // When generating the bindings for this WIT world
         let common = Common {
-            wit_path: Some(wit.path().into()),
+            wit_path: vec![wit.path().into()],
             world: None,
             world_module: Some("bindings".into()),
             quiet: false,
@@ -398,7 +399,7 @@ mod tests {
 
         // When generating the bindings for this WIT world
         let common = Common {
-            wit_path: Some(wit.path().into()),
+            wit_path: vec![wit.path().into()],
             world: None,
             world_module: Some("bindings".into()),
             quiet: false,
@@ -426,7 +427,7 @@ mod tests {
         let wit = gated_x_wit_file()?;
         let out_dir = tempfile::tempdir()?;
         let common = Common {
-            wit_path: Some(wit.path().into()),
+            wit_path: vec![wit.path().into()],
             world: None,
             world_module: Some("bindings".into()),
             quiet: false,

--- a/src/python.rs
+++ b/src/python.rs
@@ -19,7 +19,7 @@ use {
 #[pyo3(name = "componentize")]
 #[pyo3(signature = (wit_path, world, features, all_features, world_module, python_path, module_worlds, app_name, output_path, stub_wasi, import_interface_names, export_interface_names))]
 fn python_componentize(
-    wit_path: Option<PathBuf>,
+    wit_path: Vec<PathBuf>,
     world: Option<&str>,
     features: Vec<String>,
     all_features: bool,
@@ -34,7 +34,7 @@ fn python_componentize(
 ) -> PyResult<()> {
     (|| {
         Runtime::new()?.block_on(crate::componentize(
-            wit_path.as_deref(),
+            &wit_path,
             world,
             &features,
             all_features,
@@ -66,7 +66,7 @@ fn python_componentize(
 #[pyo3(name = "generate_bindings")]
 #[pyo3(signature = (wit_path, world, features, all_features, world_module, output_dir, import_interface_names, export_interface_names))]
 fn python_generate_bindings(
-    wit_path: PathBuf,
+    wit_path: Vec<PathBuf>,
     world: Option<&str>,
     features: Vec<String>,
     all_features: bool,

--- a/src/test.rs
+++ b/src/test.rs
@@ -61,7 +61,7 @@ async fn make_component(
     }
 
     crate::componentize(
-        Some(&tempdir.path().join("app.wit")),
+        &[tempdir.path().join("app.wit")],
         None,
         &[],
         false,


### PR DESCRIPTION
Hello, this PR just adds support for multiple `-d` (`--wit-path`) like `wit-bindgen`.

```bash
# Assume that the last WIT directory "./wit" has a world named "my_world"
componentize-py \
    -d "./wit/core" \
    -d "./wit/proto" \
    -d "./wit" \
    --world my_world --world-module my_world \
    componentize --stub-wasi bindgen
```
