### PR TITLE
fix stream/future tests to handle actual asynchrony

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "componentize-py"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -508,13 +508,13 @@ dependencies = [
  "test-generator",
  "tokio",
  "toml 0.8.23",
- "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
- "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
+ "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
+ "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
  "wasmtime",
  "wasmtime-wasi",
  "wit-component 0.240.0",
  "wit-dylib",
- "wit-parser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
+ "wit-parser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
  "zstd",
 ]
 
@@ -3132,19 +3132,19 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59#b1d8ff591bcb8c052b54c3c17495bbbef401897c"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5#37f05db5d62705c433e1231241dd6e3dcc234b53"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59)",
+ "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
 ]
 
 [[package]]
 name = "wasm-encoder"
 version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50#fac9fb5065c9d4b3adc057fc83df67f49cf1687f"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59#b1d8ff591bcb8c052b54c3c17495bbbef401897c"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
+ "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59)",
 ]
 
 [[package]]
@@ -3169,6 +3169,17 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.240.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5#37f05db5d62705c433e1231241dd6e3dcc234b53"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
+ "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.240.0"
 source = "git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59#b1d8ff591bcb8c052b54c3c17495bbbef401897c"
 dependencies = [
  "anyhow",
@@ -3182,17 +3193,6 @@ dependencies = [
  "url",
  "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59)",
  "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59)",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50#fac9fb5065c9d4b3adc057fc83df67f49cf1687f"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
- "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
 ]
 
 [[package]]
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59#b1d8ff591bcb8c052b54c3c17495bbbef401897c"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5#37f05db5d62705c433e1231241dd6e3dcc234b53"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50#fac9fb5065c9d4b3adc057fc83df67f49cf1687f"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=b1d8ff59#b1d8ff591bcb8c052b54c3c17495bbbef401897c"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50#fac9fb5065c9d4b3adc057fc83df67f49cf1687f"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5#37f05db5d62705c433e1231241dd6e3dcc234b53"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4033,21 +4033,21 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
- "wasm-metadata 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
- "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
- "wit-parser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
+ "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
+ "wasm-metadata 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
+ "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
+ "wit-parser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
 ]
 
 [[package]]
 name = "wit-dylib"
 version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50#fac9fb5065c9d4b3adc057fc83df67f49cf1687f"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5#37f05db5d62705c433e1231241dd6e3dcc234b53"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
- "wit-parser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
+ "wasm-encoder 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
+ "wit-parser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
 ]
 
 [[package]]
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.240.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50#fac9fb5065c9d4b3adc057fc83df67f49cf1687f"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5#37f05db5d62705c433e1231241dd6e3dcc234b53"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4105,7 +4105,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=fac9fb50)",
+ "wasmparser 0.240.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=37f05db5)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "componentize-py"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2024"
 exclude = ["cpython"]
 
@@ -14,12 +14,15 @@ clap = { version = "4.5.20", features = ["derive"] }
 tar = "0.4.42"
 tempfile = "3.13.0"
 zstd = "0.13.2"
-# TODO: switch to wasm-tools release once https://github.com/bytecodealliance/wasm-tools/pull/2367 has been merged and released
-wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "fac9fb50", features = ["wasmparser"] }
-wit-dylib = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "fac9fb50" }
-wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "fac9fb50" }
-wit-component = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "fac9fb50" }
-wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "fac9fb50" }
+# TODO: switch to wasm-tools release once
+# https://github.com/bytecodealliance/wasm-tools/pull/2367 and
+# https://github.com/bytecodealliance/wasm-tools/pull/2371 have been merged and
+# released
+wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "37f05db5", features = ["wasmparser"] }
+wit-dylib = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "37f05db5" }
+wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "37f05db5" }
+wit-component = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "37f05db5" }
+wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "37f05db5" }
 indexmap = "2.6.0"
 bincode = "1.3.3"
 heck = "0.5.0"

--- a/bundled/componentize_py_async_support/__init__.py
+++ b/bundled/componentize_py_async_support/__init__.py
@@ -483,6 +483,9 @@ def callback(event0: int, event1: int, event2: int) -> int:
                 case _:
                     # todo
                     raise NotImplementedError
+        case _Event.STREAM_READ | _Event.STREAM_WRITE | _Event.FUTURE_READ | _Event.FUTURE_WRITE:
+            componentize_py_runtime.waitable_join(event1, 0)
+            future_state.futures.pop(event1).set_result(event2)
         case _:
             # todo
             raise NotImplementedError

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-cli] `command` world.
 ## Prerequisites
 
 * `Wasmtime` 38.0.0 or later
-* `componentize-py` 0.19.1
+* `componentize-py` 0.19.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v38.0.0.
 
 ```
 cargo install --version 38.0.0 wasmtime-cli
-pip install componentize-py==0.19.1
+pip install componentize-py==0.19.2
 ```
 
 ## Running the demo

--- a/examples/http-p3/README.md
+++ b/examples/http-p3/README.md
@@ -11,7 +11,7 @@ run a Python-based component targetting version `0.3.0-rc-2025-09-16` of the
 ## Prerequisites
 
 * `Wasmtime` 38.0.0 or later
-* `componentize-py` 0.19.1
+* `componentize-py` 0.19.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v38.0.0.
 
 ```
 cargo install --version 38.0.0 wasmtime-cli
-pip install componentize-py==0.19.1
+pip install componentize-py==0.19.2
 ```
 
 ## Running the demo

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -10,7 +10,7 @@ run a Python-based component targetting the [wasi-http] `proxy` world.
 ## Prerequisites
 
 * `Wasmtime` 38.0.0 or later
-* `componentize-py` 0.19.1
+* `componentize-py` 0.19.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -18,7 +18,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v38.0.0.
 
 ```
 cargo install --version 38.0.0 wasmtime-cli
-pip install componentize-py==0.19.1
+pip install componentize-py==0.19.2
 ```
 
 ## Running the demo

--- a/examples/matrix-math/README.md
+++ b/examples/matrix-math/README.md
@@ -11,7 +11,7 @@ within a guest component.
 ## Prerequisites
 
 * `wasmtime` 38.0.0 or later
-* `componentize-py` 0.19.1
+* `componentize-py` 0.19.2
 * `NumPy`, built for WASI
 
 Note that we use an unofficial build of NumPy since the upstream project does
@@ -23,7 +23,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v38.0.0.
 
 ```
 cargo install --version 38.0.0 wasmtime-cli
-pip install componentize-py==0.19.1
+pip install componentize-py==0.19.2
 curl -OL https://github.com/dicej/wasi-wheels/releases/download/v0.0.2/numpy-wasi.tar.gz
 tar xf numpy-wasi.tar.gz
 ```

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -8,10 +8,10 @@ sandboxed Python code snippets from within a Python app.
 ## Prerequisites
 
 * `wasmtime-py` 38.0.0 or later
-* `componentize-py` 0.19.1
+* `componentize-py` 0.19.2
 
 ```
-pip install componentize-py==0.19.1 wasmtime==38.0.0
+pip install componentize-py==0.19.2 wasmtime==38.0.0
 ```
 
 ## Running the demo

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -11,7 +11,7 @@ making an outbound TCP request using `wasi-sockets`.
 ## Prerequisites
 
 * `Wasmtime` 38.0.0 or later
-* `componentize-py` 0.19.1
+* `componentize-py` 0.19.2
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
@@ -19,7 +19,7 @@ https://github.com/bytecodealliance/wasmtime/releases/tag/v38.0.0.
 
 ```
 cargo install --version 38.0.0 wasmtime-cli
-pip install componentize-py==0.19.1
+pip install componentize-py==0.19.2
 ```
 
 ## Running the demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "componentize-py"
-version = "0.19.1"
+version = "0.19.2"
 description = "Tool to package Python applications as WebAssembly components"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -300,6 +300,7 @@ mod async_ {
             buffer: *mut u8,
         },
         StreamWrite {
+            _call: Option<MyCall<'static>>,
             _values: Option<Py<PyBytes>>,
             resources: Option<Vec<Vec<EmptyResource>>>,
         },
@@ -627,6 +628,7 @@ mod async_ {
                             [
                                 usize::try_from(handle).unwrap(),
                                 Box::into_raw(Box::new(async_::Promise::StreamWrite {
+                                    _call: None,
                                     _values: Some(values.unbind()),
                                     resources: None,
                                 })) as usize,
@@ -688,6 +690,7 @@ mod async_ {
                                 [
                                     usize::try_from(handle).unwrap(),
                                     Box::into_raw(Box::new(async_::Promise::StreamWrite {
+                                        _call: Some(call),
                                         _values: None,
                                         resources: need_restore_resources.then_some(resources),
                                     })) as usize,


### PR DESCRIPTION
Due to the `wit-dylib` issue that
https://github.com/bytecodealliance/wasm-tools/pull/2371 addresses, these tests weren't actually testing what I thought they were.  Fixing that revealed a couple of bugs involving stream writes, which this fixes.

Also, bump version to 0.19.2