### PR TITLE
update test.yaml to use specific Wasmtime version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,7 +134,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: wasmtime-cli
+          tool: wasmtime-cli@39.0.1
 
       - uses: actions/setup-python@v5
         with:

--- a/examples/http-p3/README.md
+++ b/examples/http-p3/README.md
@@ -10,15 +10,15 @@ run a Python-based component targetting version `0.3.0-rc-2025-09-16` of the
 
 ## Prerequisites
 
-* `Wasmtime` 38.0.0 or later
+* `Wasmtime` 39.0.1
 * `componentize-py` 0.19.3
 
 Below, we use [Rust](https://rustup.rs/)'s `cargo` to install `Wasmtime`.  If
 you don't have `cargo`, you can download and install from
-https://github.com/bytecodealliance/wasmtime/releases/tag/v38.0.0.
+https://github.com/bytecodealliance/wasmtime/releases/tag/v39.0.1.
 
 ```
-cargo install --version 38.0.0 wasmtime-cli
+cargo install --version 39.0.1 wasmtime-cli
 pip install componentize-py==0.19.3
 ```
 


### PR DESCRIPTION
Wasmtime 40 and later include component model ABI changes that we don't support yet.