### PR TITLE
Ensure output directory exists before writing component (#162)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,6 +704,10 @@ pub async fn componentize(
         )
     })?;
 
+    // Checks if the output directory exists, and creates it if it doesn't.
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
     fs::write(output_path, component)?;
 
     Ok(())


### PR DESCRIPTION
## Summary
This change ensures that the output directory exists before writing the file, preventing potential runtime errors if the directory is missing.

## Changes
- Added output directory creation using `fs::create_dir_all` before writing to `output_path.`

## Related Issues
Fixes #162