### PR TITLE
avoid generating duplicate stream and future constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
  "async-trait",
  "futures",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
 ]
 
@@ -507,13 +507,14 @@ dependencies = [
  "test-generator",
  "tokio",
  "toml 0.8.23",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
  "wasmtime",
  "wasmtime-wasi",
- "wit-component",
+ "wit-bindgen-core 0.53.1",
+ "wit-component 0.245.1",
  "wit-dylib",
- "wit-parser 0.244.0",
+ "wit-parser 0.245.1",
  "zstd",
 ]
 
@@ -946,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,7 +1135,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
 
@@ -1137,6 +1144,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -3138,6 +3150,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,6 +3176,18 @@ dependencies = [
  "url",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da55e60097e8b37b475a0fa35c3420dd71d9eb7bd66109978ab55faf56a57efb"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -3177,6 +3211,19 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
  "indexmap",
  "semver",
  "serde",
@@ -3919,6 +3966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-core"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deda4b7e9f522d994906f6e6e0fc67965ea8660306940a776b76732be8f3933"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.245.1",
+]
+
+[[package]]
 name = "wit-bindgen-rust"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,9 +3987,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.52.0",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -3945,7 +4003,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core",
+ "wit-bindgen-core 0.52.0",
  "wit-bindgen-rust",
 ]
 
@@ -3963,21 +4021,40 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
  "wit-parser 0.244.0",
 ]
 
 [[package]]
-name = "wit-dylib"
-version = "0.244.0"
+name = "wit-component"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3ed23ad7d72a88d566eaaae4d2b6bc2c3b86a6af92d0b0d6a5511ca6e9b6c9"
+checksum = "4894f10d2d5cbc17c77e91f86a1e48e191a788da4425293b55c98b44ba3fcac9"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.245.1",
+ "wasm-metadata 0.245.1",
+ "wasmparser 0.245.1",
+ "wit-parser 0.245.1",
+]
+
+[[package]]
+name = "wit-dylib"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfce934866f549164ec28f91d9b0db4a6e9b4c31f87090cf01504f249e630dc"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.244.0",
- "wit-parser 0.244.0",
+ "wasm-encoder 0.245.1",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]
@@ -4019,6 +4096,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ clap = { version = "4.5.20", features = ["derive"] }
 tar = "0.4.42"
 tempfile = "3.13.0"
 zstd = "0.13.2"
-wasm-encoder = { version = "0.244.0", features = ["wasmparser"] }
-wit-dylib = "0.244.0"
-wit-parser = "0.244.0"
-wit-component = "0.244.0"
-wasmparser = "0.244.0"
+wasm-encoder = { version = "0.245.0", features = ["wasmparser"] }
+wit-dylib = "0.245.0"
+wit-parser = "0.245.0"
+wit-component = "0.245.0"
+wasmparser = "0.245.0"
 indexmap = "2.6.0"
 bincode = "1.3.3"
 heck = "0.5.0"
@@ -45,6 +45,7 @@ im-rc = "15.1.0"
 serde = { version = "1.0.213", features = ["derive"] }
 toml = "0.8.19"
 semver = "1.0.23"
+wit-bindgen-core = "0.53.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,7 @@ pub async fn componentize(
         docs: Default::default(),
         stability: Stability::Unknown,
         includes: Default::default(),
-        include_names: Default::default(),
+        span: Default::default(),
     });
 
     resolve.packages[union_package]
@@ -803,7 +803,7 @@ fn add_wasi_and_stubs(
                         .or_default()
                         .push(Stub::Function(&function.name, &function.kind));
                 }
-                WorldItem::Type(id) => {
+                WorldItem::Type { id, .. } => {
                     let ty = &resolve.types[*id];
                     if let TypeDefKind::Resource = &ty.kind {
                         stubs

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,20 +1,15 @@
 use {
     std::iter,
-    wit_parser::{Flags, FlagsRepr, Type},
+    wit_parser::{Flags, FlagsRepr, Param, Type},
 };
 
 pub trait Types {
     fn types(&self) -> Box<dyn Iterator<Item = Type>>;
 }
 
-impl Types for &[(String, Type)] {
+impl Types for &[Param] {
     fn types(&self) -> Box<dyn Iterator<Item = Type>> {
-        Box::new(
-            self.iter()
-                .map(|(_, ty)| *ty)
-                .collect::<Vec<_>>()
-                .into_iter(),
-        )
+        Box::new(self.iter().map(|p| p.ty).collect::<Vec<_>>().into_iter())
     }
 }
 


### PR DESCRIPTION
Previously, we used the payload type to avoid generating duplicates, but that doesn't work reliably because `wit-parser` does not necessarily deduplicate types involving aliases, such as the following example:

```
interface types {
  variant foo {
    bar,
    baz
  }
}

interface use-types-a {
  use types.{foo};

  test: func() -> future<result<foo>>;
}

interface use-types-b {
  use types.{foo};

  test: func() -> future<result<foo>>;
}
```

When targetting a world which imports and/or exports both `use-types-a` and `use-types-b`, we'll end up with distinct type IDs for `result<foo>`.

This commit switches to using `wit-bindgen-core` to determine the "canonical" type of the payload and then use that as the deduplication key.  This unblocks using `wasi:cli@0.3.0-rc-2026-02-09`, which has a similar pattern to the above WIT example.

Note that this is awkward to test given our current test infra, but #205 will cover it once it's merged.