### PR TITLE
Recognize .abi3.so native extensions in linker scanner

### DIFF
--- a/src/prelink.rs
+++ b/src/prelink.rs
@@ -16,7 +16,17 @@ use zstd::Decoder;
 
 use crate::{ComponentizePyConfig, ConfigContext, Library, RawComponentizePyConfig};
 
-static NATIVE_EXTENSION_SUFFIX: &str = ".cpython-314-wasm32-wasi.so";
+static NATIVE_EXTENSION_SUFFIXES: &[&str] = &[
+    ".cpython-314-wasm32-wasi.so",
+    ".abi3.so",
+];
+
+/// Check if a file starts with the WASM magic bytes (`\0asm`).
+fn is_wasm_file(path: &Path) -> bool {
+    fs::read(path)
+        .map(|bytes| bytes.starts_with(b"\0asm"))
+        .unwrap_or(false)
+}
 
 type ConfigsMatchedWorlds<'a> =
     IndexMap<String, (ConfigContext<ComponentizePyConfig>, Option<&'a str>)>;
@@ -235,7 +245,9 @@ fn search_directory(
             search_directory(root, &entry?.path(), libraries, configs, modules_seen)?;
         }
     } else if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
-        if name.ends_with(NATIVE_EXTENSION_SUFFIX) {
+        if NATIVE_EXTENSION_SUFFIXES.iter().any(|suffix| name.ends_with(suffix))
+            && is_wasm_file(path)
+        {
             libraries.push(path.to_owned());
         } else if name == "componentize-py.toml" {
             let root = root

--- a/src/prelink.rs
+++ b/src/prelink.rs
@@ -16,10 +16,7 @@ use zstd::Decoder;
 
 use crate::{ComponentizePyConfig, ConfigContext, Library, RawComponentizePyConfig};
 
-static NATIVE_EXTENSION_SUFFIXES: &[&str] = &[
-    ".cpython-314-wasm32-wasi.so",
-    ".abi3.so",
-];
+static NATIVE_EXTENSION_SUFFIXES: &[&str] = &[".cpython-314-wasm32-wasi.so", ".abi3.so"];
 
 /// Check if a file starts with the WASM magic bytes (`\0asm`).
 fn is_wasm_file(path: &Path) -> bool {
@@ -245,7 +242,9 @@ fn search_directory(
             search_directory(root, &entry?.path(), libraries, configs, modules_seen)?;
         }
     } else if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
-        if NATIVE_EXTENSION_SUFFIXES.iter().any(|suffix| name.ends_with(suffix))
+        if NATIVE_EXTENSION_SUFFIXES
+            .iter()
+            .any(|suffix| name.ends_with(suffix))
             && is_wasm_file(path)
         {
             libraries.push(path.to_owned());


### PR DESCRIPTION
## Summary

- Add `.abi3.so` to the set of recognized native extension suffixes in the linker's directory scanner, so stable-ABI extensions are discovered without requiring manual renaming to `.cpython-314-wasm32-wasi.so`
- Add WASM magic byte validation (`\0asm`) before treating a matched file as a native WASM extension, preventing native (ELF) `.so`/`.abi3.so` files from being misidentified

## Context

CPython's `EXTENSION_SUFFIXES` on wasm32-wasi includes `['.cpython-314-wasm32-wasi.so', '.abi3.so', '.so']`, but `prelink.rs` only matched the first suffix. This meant stable-ABI extensions (e.g. `_singlestoredb_accel.abi3.so`) had to be manually renamed before componentize-py could bundle them.

The WASM magic check ensures that if a `.abi3.so` file happens to be a native Linux binary (e.g. when a `.venv` directory is under a `-p` search path), it is silently skipped rather than causing a linker error.

## Test plan

- [x] Verified with a Python component that includes a `.abi3.so` WASM extension — componentize-py discovers and links it without renaming
- [x] Verified that native Linux `.abi3.so` files (e.g. from a `.venv` in a `-p` path) are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)