### PR TITLE
apply `default-visibility=hidden` to runtime crate

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -506,7 +506,7 @@ fn make_runtime(
 
     cmd.env(
         "RUSTFLAGS",
-        "-C relocation-model=pic --cfg pyo3_disable_reference_pool",
+        "-C relocation-model=pic -Z default-visibility=hidden --cfg pyo3_disable_reference_pool",
     )
     .env("CARGO_TARGET_DIR", out_dir.join(target))
     .env("PYO3_CONFIG_FILE", out_dir.join("pyo3-config.txt"));


### PR DESCRIPTION
# Reasoning
Over at https://github.com/influxdata/datafusion-udf-wasm I was noticing something: when switching from [static linking](https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md) to [dynamic linking](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md) our WASM artifact sizes grew A LOT (like nearly double). To some extend this makes sense because code is no longer munched together, but the magnitude of it was still a bit surprising. After some investigation if found that the Rust `.so` (by creating a static lib and than using `clang` to convert it to a dynamic lib) had a massive `exports` section. We do a bit more in our Rust code than the componentize-py `runtime` crate, and it exported basically every single Rust function including a lot of mangled ones that you'll never call from any other WASM module. After a bit of investigation I found this rustc toggle:

https://doc.rust-lang.org/beta/unstable-book/compiler-flags/default-visibility.html

Using this fixed the issue for us and I was wondering if that applies to componentize-py as well. It turns out it does but the effect isn't as stark but I think it still helps #98 somewhat.

# Comparison
Against f340fb56f45213342ce400de95b2ae1f616ff7f7 .

Compiling this:

```wit
package example:hello;
world hello {
  export hello: func() -> string;
}
```

and

```python
import wit_world
class WitWorld(wit_world.WitWorld):
    def hello(self) -> str:
        return "Hello, World!"
```

with

```console
$ componentize-py -d hello.wit -w hello componentize --stub-wasi app -o app.wasm
```

and also a debug-stripped version:

```console
$ wasm-tools strip --delete '\.debug_.*' --output app.stripped.wasm app.wasm
```

## Baseline
Sizes:
- `app.wasm`: 42702778
- `app.stripped.wasm`: 19605360
- `libcomponentize_py_runtime_sync.so`: 1482413

Objdump:

```console
$ wasm-tools objdump libcomponentize_py_runtime_sync.so
  custom "dylink.0"                      |       0x13 -       0x38 |        37 bytes | 1 count
  types                                  |       0x3b -      0x34a |       783 bytes | 91 count
  imports                                |      0x34e -     0x4880 |     17714 bytes | 445 count
  functions                              |     0x4883 -     0x543c |      3001 bytes | 2999 count
  globals                                |     0x543f -     0x554d |       270 bytes | 39 count
  exports                                |     0x5551 -    0x2f8b1 |    172896 bytes | 2027 count
  start                                  |    0x2f8b3 -    0x2f8b5 |         2 bytes | 1 count
  elements                               |    0x2f8b8 -    0x2fdc1 |      1289 bytes | 1 count
  code                                   |    0x2fdc5 -   0x10e9b8 |    912371 bytes | 2999 count
  data                                   |   0x10e9bc -   0x1292e4 |    108840 bytes | 2 count
  custom ".debug_abbrev"                 |   0x1292f4 -   0x12935d |       105 bytes | 1 count
  custom ".debug_info"                   |   0x12936c -   0x1293ef |       131 bytes | 1 count
  custom ".debug_str"                    |   0x1293fd -   0x129559 |       348 bytes | 1 count
  custom ".debug_line"                   |   0x129568 -   0x1295f8 |       144 bytes | 1 count
  custom "component-type:wit-bindgen:0.52.0:componentize-py:init:init:encoded world" |   0x129645 -   0x129a6c |      1063 bytes | 1 count
  custom "name"                          |   0x129a75 -   0x169d49 |    262868 bytes | 1 count
  custom "producers"                     |   0x169d56 -   0x169e06 |       176 bytes | 1 count
  custom "target_features"               |   0x169e19 -   0x169ead |       148 bytes | 1 count

```

## PR
Sizes:
- `app.wasm`: 41486014
- `app.stripped.wasm`: 18388605
- `libcomponentize_py_runtime_sync.so`: 371566

Objdump:

```console
$ wasm-tools objdump libcomponentize_py_runtime_sync.so 
  custom "dylink.0"                      |       0x13 -       0x38 |        37 bytes | 1 count
  types                                  |       0x3b -      0x102 |       199 bytes | 29 count
  imports                                |      0x105 -      0xbcb |      2758 bytes | 114 count
  functions                              |      0xbce -      0xed6 |       776 bytes | 774 count
  globals                                |      0xed8 -      0xf32 |        90 bytes | 11 count
  exports                                |      0xf35 -     0x15ae |      1657 bytes | 70 count
  start                                  |     0x15b0 -     0x15b1 |         1 bytes | 1 count
  elements                               |     0x15b4 -     0x17d9 |       549 bytes | 1 count
  code                                   |     0x17dd -    0x3d72a |    245581 bytes | 774 count
  data                                   |    0x3d72e -    0x44b0a |     29660 bytes | 2 count
  custom ".debug_abbrev"                 |    0x44b1a -    0x44b83 |       105 bytes | 1 count
  custom ".debug_info"                   |    0x44b92 -    0x44c15 |       131 bytes | 1 count
  custom ".debug_str"                    |    0x44c23 -    0x44d7f |       348 bytes | 1 count
  custom ".debug_line"                   |    0x44d8e -    0x44e1e |       144 bytes | 1 count
  custom "component-type:wit-bindgen:0.52.0:componentize-py:init:init:encoded world" |    0x44e6b -    0x45292 |      1063 bytes | 1 count
  custom "name"                          |    0x4529b -    0x5aa0a |     87919 bytes | 1 count
  custom "producers"                     |    0x5aa17 -    0x5aac7 |       176 bytes | 1 count
  custom "target_features"               |    0x5aada -    0x5ab6e |       148 bytes | 1 count
```