### PR TITLE
Escape triple quotes in generated Python docstrings

### DIFF
--- a/src/summary.rs
+++ b/src/summary.rs
@@ -2661,12 +2661,20 @@ fn docstring(docs: Option<&str>, indent_level: usize, error: Option<&str>) -> St
             .map(|_| "    ")
             .collect::<Vec<_>>()
             .concat();
+        // WIT docs may contain `"""` and/or `'''`.  Use a delimiter that does
+        // not appear in the text; if both do, escape `"""` so a `"""` wrapper
+        // remains valid Python.
+        let (quote, docs) = match (docs.contains(r#"""""#), docs.contains("'''")) {
+            (true, true) => (r#"""""#, docs.replace(r#"""""#, r#"\""""#)),
+            (true, false) => ("'''", docs),
+            _ => (r#"""""#, docs),
+        };
         let docs = docs
             .lines()
             .map(|line| format!("{indent}{line}\n"))
             .collect::<Vec<_>>()
             .concat();
-        format!(r#""""{newline}{docs}{indent}"""{newline}{indent}"#)
+        format!("{quote}{newline}{docs}{indent}{quote}{newline}{indent}")
     } else {
         String::new()
     }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -2662,10 +2662,10 @@ fn docstring(docs: Option<&str>, indent_level: usize, error: Option<&str>) -> St
             .collect::<Vec<_>>()
             .concat();
         // WIT docs may contain `"""` and/or `'''`.  Use a delimiter that does
-        // not appear in the text; if both do, escape `"""` so a `"""` wrapper
-        // remains valid Python.
+        // not appear in the text; if both do, escape `\` then every `"` so a
+        // `"""` wrapper remains valid Python.
         let (quote, docs) = match (docs.contains(r#"""""#), docs.contains("'''")) {
-            (true, true) => (r#"""""#, docs.replace(r#"""""#, r#"\""""#)),
+            (true, true) => (r#"""""#, docs.replace('\\', "\\\\").replace('"', "\\\"")),
             (true, false) => ("'''", docs),
             _ => (r#"""""#, docs),
         };

--- a/tests/bindings.rs
+++ b/tests/bindings.rs
@@ -190,6 +190,66 @@ fn lint_tcp_p3_bindings() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn docstring_triple_quotes_are_valid_python() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    fs::write(
+        dir.path().join("example.wit"),
+        r#"package demo:poc;
+
+world example {
+  /// """
+  export hello: func(name: string) -> string;
+
+  /// docs containing both """ and '''
+  export both: func() -> string;
+}
+"#,
+    )?;
+
+    cargo::cargo_bin_cmd!("componentize-py")
+        .current_dir(dir.path())
+        .args(["-d", "example.wit", "-w", "example", "bindings", "."])
+        .assert()
+        .success();
+
+    assert!(predicate::path::is_dir().eval(&dir.path().join("wit_world")));
+
+    Command::new("python3")
+        .current_dir(dir.path())
+        .args([
+            "-c",
+            r#"
+import ast
+import sys
+from pathlib import Path
+
+docs_by_name = {}
+for path in Path(".").rglob("*.py"):
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node)
+            if doc:
+                docs_by_name.setdefault(node.name, []).append(doc)
+
+hello_docs = docs_by_name.get("hello", [])
+if not any('"""' in doc for doc in hello_docs):
+    sys.stderr.write("hello docstring lost triple double quotes: %r\n" % hello_docs)
+    sys.exit(1)
+
+both_docs = docs_by_name.get("both", [])
+if not any(("'''" in doc and '"""' in doc) for doc in both_docs):
+    sys.stderr.write("both docstring lost quote sequences: %r\n" % both_docs)
+    sys.exit(1)
+"#,
+        ])
+        .assert()
+        .success();
+
+    Ok(())
+}
+
 fn generate_bindings(path: &Path, world: &str) -> Result<Assert, anyhow::Error> {
     Ok(cargo::cargo_bin_cmd!("componentize-py")
         .current_dir(path)

--- a/tests/bindings.rs
+++ b/tests/bindings.rs
@@ -203,6 +203,12 @@ world example {
 
   /// docs containing both """ and '''
   export both: func() -> string;
+
+  /// docs containing both """" and '''
+  export four: func() -> string;
+
+  /// docs containing both \""" and '''
+  export backslash: func() -> string;
 }
 "#,
     )?;
@@ -241,6 +247,16 @@ if not any('"""' in doc for doc in hello_docs):
 both_docs = docs_by_name.get("both", [])
 if not any(("'''" in doc and '"""' in doc) for doc in both_docs):
     sys.stderr.write("both docstring lost quote sequences: %r\n" % both_docs)
+    sys.exit(1)
+
+four_docs = docs_by_name.get("four", [])
+if not any(("'''" in doc and '""""' in doc) for doc in four_docs):
+    sys.stderr.write("four docstring lost quote sequences: %r\n" % four_docs)
+    sys.exit(1)
+
+backslash_docs = docs_by_name.get("backslash", [])
+if not any(("'''" in doc and '\\"""' in doc) for doc in backslash_docs):
+    sys.stderr.write("backslash docstring lost quote sequences: %r\n" % backslash_docs)
     sys.exit(1)
 "#,
         ])


### PR DESCRIPTION
WIT `///` documentation that contains `"""` was copied verbatim into generated Python `"""..."""` docstrings, which is a `SyntaxError` (`python -m py_compile` fails).

Fixes #194

## Summary

Generated Python bindings are now valid even when WIT docs include `"""` (and when they include both `"""` and `'''`). Documentation text is preserved.

## Changes

- Update `docstring()` in `src/summary.rs` to pick a triple-quote delimiter that does not appear in the docs. If both `"""` and `'''` are present, escape `"""` as `\"\"\"` and wrap with `"""`.
- Add a bindings regression test using the issue WIT (plus a function whose docs contain both quote styles). The test generates stubs, `ast.parse`s the output (so invalid Python fails), and asserts the documentation text is still present.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --tests -- -D warnings`
- `cargo test --test bindings docstring_triple_quotes_are_valid_python` — passed