### PR TITLE
don't skip CI if example code changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*"
     paths-ignore:
-      - "examples/**"
+      - "examples/**/README.md"
       - "README.md"
       - "CONTRIBUTING.md"
   workflow_dispatch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - "examples/**"
+      - "examples/**/README.md"
       - "README.md"
       - "CONTRIBUTING.md"
   workflow_dispatch:


### PR DESCRIPTION
We test that code in CI now, so we should run it if the code changes (but we can still skip it if only the README.md files change).