### PR TITLE
set resource/future/stream handles to zero to invalidate

### DIFF
--- a/bundled/componentize_py_async_support/futures.py
+++ b/bundled/componentize_py_async_support/futures.py
@@ -29,7 +29,7 @@ class FutureReader(Generic[T]):
 
         """
         self.type_ = type_
-        self.handle: int | None = handle
+        self.handle: int = handle
         self.finalizer = weakref.finalize(self, componentize_py_runtime.future_drop_readable, type_, handle)
 
     async def read(self) -> T:
@@ -45,8 +45,8 @@ class FutureReader(Generic[T]):
         
         self.finalizer.detach()
         handle = self.handle
-        self.handle = None
-        if handle is not None:
+        self.handle = 0
+        if handle != 0:
             result = await componentize_py_async_support.await_result(
                 componentize_py_runtime.future_read(self.type_, handle)
             )
@@ -62,10 +62,10 @@ class FutureReader(Generic[T]):
                  exc_type: type[BaseException] | None,
                  exc_value: BaseException | None,
                  traceback: TracebackType | None) -> bool | None:
-        if self.handle is not None:
+        if self.handle != 0:
             self.finalizer.detach()
             handle = self.handle
-            self.handle = None
+            self.handle = 0
             componentize_py_runtime.future_drop_readable(self.type_, handle)
 
         return None
@@ -100,7 +100,7 @@ class FutureWriter(Generic[T]):
 
         """
         self.type_ = type_
-        self.handle: int | None = handle
+        self.handle: int = handle
         self.default = default
         self.finalizer = weakref.finalize(self, _write_default, type_, handle, default)
 
@@ -117,8 +117,8 @@ class FutureWriter(Generic[T]):
         """
         self.finalizer.detach()
         handle = self.handle
-        self.handle = None
-        if handle is not None:
+        self.handle = 0
+        if handle != 0:
             code, _ = await componentize_py_async_support.await_result(
                 componentize_py_runtime.future_write(self.type_, handle, value)
             )
@@ -143,7 +143,7 @@ class FutureWriter(Generic[T]):
                  exc_type: type[BaseException] | None,
                  exc_value: BaseException | None,
                  traceback: TracebackType | None) -> bool | None:
-        if self.handle is not None:
+        if self.handle != 0:
             componentize_py_async_support.spawn(self.write(self.default()))
 
         return None

--- a/bundled/componentize_py_async_support/streams.py
+++ b/bundled/componentize_py_async_support/streams.py
@@ -28,7 +28,7 @@ class ByteStreamReader:
         """
         self.writer_dropped = False
         self.type_ = type_
-        self.handle: int | None = handle
+        self.handle: int = handle
         self.finalizer = weakref.finalize(self, componentize_py_runtime.stream_drop_readable, type_, handle)
 
     async def read(self, max_count: int) -> bytes:
@@ -48,7 +48,7 @@ class ByteStreamReader:
             return bytes()
         
         handle = self.handle
-        self.handle = None
+        self.handle = 0
         code, values = await self._read(max_count, handle)
         self.handle = handle
 
@@ -57,8 +57,8 @@ class ByteStreamReader:
         
         return values
         
-    async def _read(self, max_count: int, handle: int | None) -> tuple[int, bytes]:
-        if handle is not None:
+    async def _read(self, max_count: int, handle: int) -> tuple[int, bytes]:
+        if handle != 0:
             return cast(tuple[int, bytes], await componentize_py_async_support.await_result(
                 componentize_py_runtime.stream_read(self.type_, handle, max_count)
             ))
@@ -74,8 +74,8 @@ class ByteStreamReader:
                  traceback: TracebackType | None) -> bool | None:
         self.finalizer.detach()
         handle = self.handle
-        self.handle = None
-        if handle is not None:
+        self.handle = 0
+        if handle != 0:
             componentize_py_runtime.stream_drop_readable(self.type_, handle)
         return None
 
@@ -101,7 +101,7 @@ class ByteStreamWriter:
         """
         self.reader_dropped = False
         self.type_ = type_
-        self.handle: int | None = handle
+        self.handle: int = handle
         self.finalizer = weakref.finalize(self, componentize_py_runtime.stream_drop_writable, type_, handle)
 
     async def write(self, source: bytes) -> int:
@@ -125,7 +125,7 @@ class ByteStreamWriter:
             return 0
         
         handle = self.handle
-        self.handle = None
+        self.handle = 0
         code, count = await self._write(source, handle)
         self.handle = handle
 
@@ -134,8 +134,8 @@ class ByteStreamWriter:
         
         return count
 
-    async def _write(self, source: bytes, handle: int | None) -> tuple[int, int]:
-        if handle is not None:
+    async def _write(self, source: bytes, handle: int) -> tuple[int, int]:
+        if handle != 0:
             return await componentize_py_async_support.await_result(
                 componentize_py_runtime.stream_write(self.type_, handle, source)
             )
@@ -169,8 +169,8 @@ class ByteStreamWriter:
                  traceback: TracebackType | None) -> bool | None:
         self.finalizer.detach()
         handle = self.handle
-        self.handle = None
-        if handle is not None:
+        self.handle = 0
+        if handle != 0:
             componentize_py_runtime.stream_drop_writable(self.type_, handle)
         return None
 
@@ -198,7 +198,7 @@ class StreamReader(Generic[T]):
         """
         self.writer_dropped = False
         self.type_ = type_
-        self.handle: int | None = handle
+        self.handle: int = handle
         self.finalizer = weakref.finalize(self, componentize_py_runtime.stream_drop_readable, type_, handle)
 
     async def read(self, max_count: int) -> list[T]:
@@ -218,7 +218,7 @@ class StreamReader(Generic[T]):
             return []
         
         handle = self.handle
-        self.handle = None
+        self.handle = 0
         code, values = await self._read(max_count, handle)
         self.handle = handle
 
@@ -227,8 +227,8 @@ class StreamReader(Generic[T]):
         
         return values
         
-    async def _read(self, max_count: int, handle: int | None) -> tuple[int, list[T]]:
-        if handle is not None:
+    async def _read(self, max_count: int, handle: int) -> tuple[int, list[T]]:
+        if handle != 0:
             return cast(tuple[int, list[T]], await componentize_py_async_support.await_result(
                 componentize_py_runtime.stream_read(self.type_, handle, max_count)
             ))
@@ -244,8 +244,8 @@ class StreamReader(Generic[T]):
                  traceback: TracebackType | None) -> bool | None:
         self.finalizer.detach()
         handle = self.handle
-        self.handle = None
-        if handle is not None:
+        self.handle = 0
+        if handle != 0:
             componentize_py_runtime.stream_drop_readable(self.type_, handle)
         return None
 
@@ -271,7 +271,7 @@ class StreamWriter(Generic[T]):
         """
         self.reader_dropped = False
         self.type_ = type_
-        self.handle: int | None = handle
+        self.handle: int = handle
         self.finalizer = weakref.finalize(self, componentize_py_runtime.stream_drop_writable, type_, handle)
 
     async def write(self, source: list[T]) -> int:
@@ -295,7 +295,7 @@ class StreamWriter(Generic[T]):
             return 0
         
         handle = self.handle
-        self.handle = None
+        self.handle = 0
         code, count = await self._write(source, handle)
         self.handle = handle
 
@@ -304,8 +304,8 @@ class StreamWriter(Generic[T]):
         
         return count
 
-    async def _write(self, source: list[T], handle: int | None) -> tuple[int, int]:
-        if handle is not None:
+    async def _write(self, source: list[T], handle: int) -> tuple[int, int]:
+        if handle != 0:
             return await componentize_py_async_support.await_result(
                 componentize_py_runtime.stream_write(self.type_, handle, source)
             )
@@ -339,7 +339,7 @@ class StreamWriter(Generic[T]):
                  traceback: TracebackType | None) -> bool | None:
         self.finalizer.detach()
         handle = self.handle
-        self.handle = None
-        if handle is not None:
+        self.handle = 0
+        if handle != 0:
             componentize_py_runtime.stream_drop_writable(self.type_, handle)
         return None

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -162,7 +162,7 @@ fn release_borrows(py: Python, borrows: Vec<Borrow>) {
     {
         let value = value.bind(py);
 
-        value.delattr(intern!(py, "handle")).unwrap();
+        value.setattr(intern!(py, "handle"), 0u32).unwrap();
 
         value
             .getattr(intern!(py, "finalizer"))
@@ -1411,7 +1411,7 @@ impl MyCall<'_> {
             .unwrap();
 
         if owned {
-            value.bind(py).delattr(intern!(py, "handle")).unwrap();
+            value.bind(py).setattr(intern!(py, "handle"), 0u32).unwrap();
 
             let finalizer_args = value
                 .bind(py)

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1941,7 +1941,7 @@ class {camel}(Flag):
                                             "{enter}
     def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> bool | None:
         {docs}(_, func, args, _) = self.finalizer.detach()
-        self.handle = None
+        self.handle = 0
         func(args[0], args[1])
 "
                                         )

--- a/src/test/python_source/app.py
+++ b/src/test/python_source/app.py
@@ -270,6 +270,23 @@ class Tests(tests.WorldExports):
         # `MemoryError` if we're handling refcounts correctly in the runtime.
         for _ in range(5 * 1024):
             chunk = tests.get_bytes(1024 * 1024)
+
+    def trap_on_empty_resource(self, thing: imports.resource_alias1.Thing):
+        tests.take_thing(thing)
+        tests.take_thing(thing) # should trap since we already gave away `thing`
+        unreachable()
+        
+    def trap_on_empty_future(self):
+        tx, rx = tests.unit_future(lambda: None)
+        tests.take_future(rx)
+        tests.take_future(rx) # should trap since we already gave away `rx`
+        unreachable()
+        
+    def trap_on_empty_stream(self):
+        tx, rx = tests.unit_stream()
+        tests.take_stream(rx)
+        tests.take_stream(rx) # should trap since we already gave away `rx`
+        unreachable()
    
 @foo_iface.guest
 class FooInterface(foo_exports.FooInterface):

--- a/src/test/tests.rs
+++ b/src/test/tests.rs
@@ -81,6 +81,20 @@ impl TestsImports for Ctx {
     async fn get_bytes(&mut self, count: u32) -> wasmtime::Result<Vec<u8>> {
         Ok(vec![42u8; usize::try_from(count).unwrap()])
     }
+
+    async fn take_thing(&mut self, thing: Resource<ThingString>) -> wasmtime::Result<()> {
+        Ok(self.ctx().table.delete(thing).map(|_| ())?)
+    }
+
+    async fn take_future(&mut self, future: FutureReader<()>) -> wasmtime::Result<()> {
+        _ = future;
+        Ok(())
+    }
+
+    async fn take_stream(&mut self, stream: StreamReader<()>) -> wasmtime::Result<()> {
+        _ = stream;
+        Ok(())
+    }
 }
 
 impl<T> TestsImportsWithStore<T> for HasSelf<Ctx> {
@@ -1198,6 +1212,66 @@ fn filesystem() -> Result<()> {
                 .map_err(|s| anyhow!("{s}"))?;
 
             assert_eq!(&value, message);
+
+            Ok(())
+        })
+    })
+}
+
+#[test]
+fn trap_on_empty_resource() -> Result<()> {
+    TESTER.test(|world, store, runtime| {
+        runtime.block_on(async {
+            let thing = store
+                .data_mut()
+                .ctx()
+                .table
+                .push(ThingString("Ni Hao".to_string()))?;
+
+            let error = world
+                .call_trap_on_empty_resource(store, thing)
+                .await
+                .unwrap_err();
+
+            let expected = "unknown handle index 0";
+            assert!(
+                format!("{error:?}").contains(expected),
+                "expected error message to contain `{expected}`; got {error:?}"
+            );
+
+            Ok(())
+        })
+    })
+}
+
+#[test]
+fn trap_on_empty_future() -> Result<()> {
+    TESTER.test(|world, store, runtime| {
+        runtime.block_on(async {
+            let error = world.call_trap_on_empty_future(store).await.unwrap_err();
+
+            let expected = "unknown handle index 0";
+            assert!(
+                format!("{error:?}").contains(expected),
+                "expected error message to contain `{expected}`; got {error:?}"
+            );
+
+            Ok(())
+        })
+    })
+}
+
+#[test]
+fn trap_on_empty_stream() -> Result<()> {
+    TESTER.test(|world, store, runtime| {
+        runtime.block_on(async {
+            let error = world.call_trap_on_empty_stream(store).await.unwrap_err();
+
+            let expected = "unknown handle index 0";
+            assert!(
+                format!("{error:?}").contains(expected),
+                "expected error message to contain `{expected}`; got {error:?}"
+            );
 
             Ok(())
         })

--- a/src/test/wit/tests.wit
+++ b/src/test/wit/tests.wit
@@ -217,6 +217,18 @@ world tests {
 
   export test-refcounts: func();
 
+  export trap-on-empty-resource: func(thing: thing);
+
+  import take-thing: func(thing: thing);
+
+  export trap-on-empty-future: func();
+
+  import take-future: func(v: future);
+  
+  export trap-on-empty-stream: func();
+
+  import take-stream: func(v: stream);
+
   record frame {
     id: s32,
   }


### PR DESCRIPTION
This results in a more comprehensible trap if the object is accidentally used after it is invalidated.

Fixes #233